### PR TITLE
Make vertical planks planks

### DIFF
--- a/kubejs/server_scripts/vh_compat/everycompat/tags.js
+++ b/kubejs/server_scripts/vh_compat/everycompat/tags.js
@@ -1,0 +1,3 @@
+onEvent('block.tags', event => {
+    event.add('minecraft:planks', '/everycomp:q/.+/vertical_.+_planks/')
+})


### PR DESCRIPTION
Adds planks tag to vertical planks from everycompat - fixes them not being mineable in tenos paradox.



I wanted to make the supplementaries book piles mineable too, but I can't figure it out.