### PR TITLE
enable flywheel

### DIFF
--- a/configureddefaults/config/flywheel-client.toml
+++ b/configureddefaults/config/flywheel-client.toml
@@ -1,6 +1,6 @@
 #Select the backend to use.
 #Allowed Values: OFF, BATCHING, INSTANCING
-backend = "OFF"
+backend = "INSTANCING"
 #Enable or disable a debug overlay that colors pixels by their normal.
 debugNormals = false
 #Enable or disable instance update limiting with distance.


### PR DESCRIPTION
re-enable flywheel

it was disabled in vh because it was causing crashes on amd gpus. that was fixed 2 years ago in 0.6.8a, so we should reenable it for better fps