### PR TITLE
Removed mekanism assembler from Automatic Genius itemRestrictions

### DIFF
--- a/config/the_vault/researches.json
+++ b/config/the_vault/researches.json
@@ -1248,13 +1248,6 @@
     },
     {
       "itemRestrictions": {
-        "mekanism:formulaic_assemblicator": {
-          "restricts": {
-            "HITTABILITY": true,
-            "USABILITY": true,
-            "CRAFTABILITY": true
-          }
-        },
         "rftoolsutility:crafter1": {
           "restricts": {
             "HITTABILITY": true,


### PR DESCRIPTION
Due to it being supported within vault-autocrafting-fix now