### PR TITLE
vault_mobs.json : re-order to align with vanilla VH + add missing entities

### DIFF
--- a/config/the_vault/vault_mobs.json
+++ b/config/the_vault/vault_mobs.json
@@ -1,4673 +1,5 @@
 {
   "ATTRIBUTE_OVERRIDES": {
-    "the_vault:t1_cave_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 30.0,
-        "MAX": 58.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 33.0,
-            "MAX": 63.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 36.0,
-            "MAX": 69.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t2_cave_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 40.0,
-        "MAX": 60.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 44.0,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 48.0,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 52.800000000000004,
-            "MAX": 79.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 57.599999999999994,
-            "MAX": 86.39999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t3_cave_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 80.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t4_cave_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 80.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t5_cave_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 80.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:overgrown_tank": [
-      {
-        "NAME": "the_vault:generic.reach",
-        "MIN": 1.8,
-        "MAX": 1.8,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 3.3000000000000003,
-            "MAX": 5.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 3.5999999999999996,
-            "MAX": 6.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 60.0,
-        "MAX": 85.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 66.0,
-            "MAX": 93.50000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 72.0,
-            "MAX": 102.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 79.2,
-            "MAX": 112.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 86.39999999999999,
-            "MAX": 122.39999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.7,
-        "MAX": 1.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:swamp_zombie": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 75,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 41.0,
-        "MAX": 60.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 75,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 45.1,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 49.199999999999996,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 54.12,
-            "MAX": 79.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 59.03999999999999,
-            "MAX": 86.39999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:blood_tank": [
-      {
-        "NAME": "the_vault:generic.reach",
-        "MIN": 1.8,
-        "MAX": 1.8,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 68.0,
-            "MAX": 82.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 80.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 100.0,
-            "MAX": 130.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 140.0,
-            "MAX": 170.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 184.8,
-            "MAX": 224.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 201.6,
-            "MAX": 244.79999999999998,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.7,
-        "MAX": 1.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:blood_horde_t1": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.14,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.12,
-            "MAX": 0.18,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.35,
-            "MAX": 1.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 24.0,
-        "MAX": 29.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 26.400000000000002,
-            "MAX": 31.900000000000002,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 28.799999999999997,
-            "MAX": 34.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 31.68,
-            "MAX": 38.28,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 34.559999999999995,
-            "MAX": 41.76,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.05,
-        "MAX": 1.15,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:blood_horde_t2": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.14,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.12,
-            "MAX": 0.18,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.35,
-            "MAX": 1.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 38.0,
-        "MAX": 50.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 41.800000000000004,
-            "MAX": 55.00000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 45.6,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 50.160000000000004,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 54.72,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.05,
-        "MAX": 1.15,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:blood_horde_t3": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.14,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.12,
-            "MAX": 0.18,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.35,
-            "MAX": 1.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 90,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 50.0,
-        "MAX": 65.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 55.00000000000001,
-            "MAX": 71.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 60.0,
-            "MAX": 78.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 66.0,
-            "MAX": 85.80000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 72.0,
-            "MAX": 93.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.05,
-        "MAX": 1.15,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:blood_horde_t4": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 70.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 77.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 84.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 92.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 100.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.05,
-        "MAX": 1.15,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:blood_horde_t5": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.018,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.018,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.018,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 70.0,
-        "MAX": 80.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 77.0,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 84.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 92.4,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 100.8,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.05,
-        "MAX": 1.15,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:black_ghost": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 75.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.07,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:blue_ghost": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 60.0,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.07,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:brown_ghost": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.75,
-        "MAX": 1.0,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 90.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.085,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 6.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:dark_blue_ghost": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.1,
-        "MAX": 1.15,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 80.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 6.0,
-        "MAX": 6.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.75,
-            "MAX": 1.75,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:dark_red_ghost": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.1,
-        "MAX": 1.1,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 150.0,
-            "MAX": 150.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 4.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.2,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:dark_gray_ghost": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 60.0,
-            "MAX": 110.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 120.0,
-            "MAX": 150.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.065,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 6.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.2,
-            "MAX": 0.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:green_ghost": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 75.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.07,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:purple_ghost": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.05,
-        "MAX": 1.05,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 60.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 100.0,
-            "MAX": 110.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.07,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 4.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:red_ghost": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 100.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 125.0,
-            "MAX": 125.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.2,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "woldsvaults:yellow_ghost": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.25,
-        "MAX": 1.5,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 50.0,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.065,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.15,
-            "MAX": 0.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:mungus": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 12.0,
-            "MAX": 16.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 17.0,
-            "MAX": 20.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 21.0,
-            "MAX": 25.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 25.0,
-            "MAX": 28.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 29.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:void_worm": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 2.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 36.0,
-            "MAX": 54.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 55.0,
-            "MAX": 70.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 71.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 81.0,
-            "MAX": 110.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 111.0,
-            "MAX": 135.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:enderiophage": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 2.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 36.0,
-            "MAX": 54.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 55.0,
-            "MAX": 70.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 71.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 81.0,
-            "MAX": 110.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 111.0,
-            "MAX": 135.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:komodo_dragon": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 2.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 28.0,
-            "MAX": 48.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 49.0,
-            "MAX": 69.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 70.0,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 91.0,
-            "MAX": 101.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 102.0,
-            "MAX": 111.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:snow_leopard": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.2,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.25,
-            "MAX": 0.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.6,
-            "MAX": 1.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 18.0,
-            "MAX": 30.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 31.0,
-            "MAX": 39.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 40.0,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 61.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 76.0,
-            "MAX": 83.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:dropbear": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.2,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.25,
-            "MAX": 0.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.6,
-            "MAX": 1.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 18.0,
-            "MAX": 30.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 31.0,
-            "MAX": 39.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 40.0,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 61.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 76.0,
-            "MAX": 83.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:tiger": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.2,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.25,
-            "MAX": 0.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.6,
-            "MAX": 1.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 18.0,
-            "MAX": 30.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 31.0,
-            "MAX": 39.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 40.0,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 61.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 76.0,
-            "MAX": 83.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:gorilla": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 2.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 36.0,
-            "MAX": 54.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 55.0,
-            "MAX": 70.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 71.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 81.0,
-            "MAX": 110.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 111.0,
-            "MAX": 135.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:crocodile": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.15,
-            "MAX": 0.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.3,
-            "MAX": 0.45,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.4,
-            "MAX": 1.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.6,
-            "MAX": 2.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 22.0,
-            "MAX": 30.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 45.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 46.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 55.0,
-            "MAX": 70.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 71.0,
-            "MAX": 95.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:aggressive_cow": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 2.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 22.0,
-            "MAX": 30.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 31.0,
-            "MAX": 45.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 46.0,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 61.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 81.0,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:aggressive_cow_boss": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.15,
-            "MAX": 0.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.2,
-            "MAX": 0.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.25,
-            "MAX": 0.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.8,
-            "MAX": 1.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 4.0,
-        "MAX": 7.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 60.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 100.0,
-            "MAX": 120.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 130.0,
-            "MAX": 160.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 200.0,
-            "MAX": 220.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 240.0,
-            "MAX": 300.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "cloudstorage:bloviator": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 2.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 18.0,
-            "MAX": 24.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 25.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 41.0,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 61.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 81.0,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "the_vault:vault_green_gummy_soldier": [
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -5093,149 +425,6 @@
         "NAME": "minecraft:generic.movement_speed",
         "MIN": 1.01,
         "MAX": 1.02,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "alexsmobs:centipede_head": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 52.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 50.0,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 70.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 90.0,
-            "MAX": 130.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 120.0,
-            "MAX": 170.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.5,
-        "MAX": 2.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.03,
-            "MAX": 0.07,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.07,
-            "MAX": 0.10,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.1,
-        "MAX": 1.2,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -6416,174 +1605,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "grimoireofgaia:minotaur": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.25,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.5,
-            "MAX": 2.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 8.0,
-        "MAX": 8.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 110.0,
-        "MAX": 135.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.24,
-        "MAX": 0.24,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.25,
-        "MAX": 0.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "grimoireofgaia:minotaurus": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.5,
-            "MAX": 2.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 8.0,
-        "MAX": 9.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 90.0,
-        "MAX": 110.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.32,
-        "MAX": 0.32,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.25,
-        "MAX": 0.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "minecraft:zombie": [
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -6927,103 +1948,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "tropicraft:eih": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 4.0,
-        "MAX": 6.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 68.0,
-            "MAX": 82.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 80.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 100.0,
-            "MAX": 130.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 140.0,
-            "MAX": 170.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 170.0,
-            "MAX": 200.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.7,
-        "MAX": 1.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "the_vault:t3_zombie": [
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -7121,7 +2045,139 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "grimoireofgaia:cobble_golem": [
+    "the_vault:overgrown_tank": [
+      {
+        "NAME": "the_vault:generic.reach",
+        "MIN": 1.8,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 3.3000000000000003,
+            "MAX": 5.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 3.5999999999999996,
+            "MAX": 6.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 60.0,
+        "MAX": 85.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 66.0,
+            "MAX": 93.50000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 72.0,
+            "MAX": 102.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 79.2,
+            "MAX": 112.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 86.39999999999999,
+            "MAX": 122.39999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.7,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:blood_tank": [
+      {
+        "NAME": "the_vault:generic.reach",
+        "MIN": 1.8,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
       {
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
@@ -7147,112 +2203,35 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
+        "SCALE_MAX_LEVEL": -1,
         "LEVELS": [
           {
-            "MIN_LEVEL": 0,
-            "MIN": 40.0,
-            "MAX": 60.0,
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 60.0,
-            "MAX": 70.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 70.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 80.0,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 90.0,
-            "MAX": 100.0,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_PER_LEVEL": 0.05,
             "SCALE_MAX_LEVEL": -1
           }
         ]
       },
       {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.7,
-        "MAX": 1.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "grimoireofgaia:cobblestone_golem": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.25,
-        "MAX": 0.25,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.5,
-        "MAX": 1.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 4.0,
-        "MAX": 8.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.25,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
         "NAME": "minecraft:generic.max_health",
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 80.0,
-            "MAX": 100.0,
+            "MIN": 68.0,
+            "MAX": 82.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
@@ -7260,8 +2239,8 @@
           },
           {
             "MIN_LEVEL": 35,
-            "MIN": 100.0,
-            "MAX": 120.0,
+            "MIN": 80.0,
+            "MAX": 100.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
@@ -7269,8 +2248,8 @@
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 120.0,
-            "MAX": 140.0,
+            "MIN": 100.0,
+            "MAX": 130.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
@@ -7279,16 +2258,25 @@
           {
             "MIN_LEVEL": 65,
             "MIN": 140.0,
-            "MAX": 160.0,
+            "MAX": 170.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
             "SCALE_MAX_LEVEL": 89
           },
           {
+            "MIN_LEVEL": 80,
+            "MIN": 184.8,
+            "MAX": 224.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
             "MIN_LEVEL": 90,
-            "MIN": 160.0,
-            "MAX": 200.0,
+            "MIN": 201.6,
+            "MAX": 244.79999999999998,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
@@ -7300,103 +2288,6 @@
         "NAME": "minecraft:generic.knockback_resistance",
         "MIN": 0.7,
         "MAX": 1.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "grimoireofgaia:flesh_lich": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.1,
-        "MAX": 0.1,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.5,
-        "MAX": 1.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 4.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 40.0,
-            "MAX": 50.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 59.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 87.0,
-            "MAX": 114.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 102.0,
-            "MAX": 144.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 125.0,
-            "MAX": 184.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.33,
-        "MAX": 0.5,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -7951,99 +2842,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "tropicraft:tropiskelly": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 80.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "the_vault:t3_skeleton": [
       {
         "NAME": "minecraft:generic.max_health",
@@ -8137,157 +2935,316 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "thermal:blizz": [
+    "the_vault:t1_cave_skeleton": [
       {
         "NAME": "minecraft:generic.max_health",
+        "MIN": 30.0,
+        "MAX": 58.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 50,
         "LEVELS": [
           {
-            "MIN_LEVEL": 0,
-            "MIN": 30.0,
-            "MAX": 60.0,
+            "MIN_LEVEL": 80,
+            "MIN": 33.0,
+            "MAX": 63.800000000000004,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
+            "SCALE_MAX_LEVEL": -1
           },
           {
-            "MIN_LEVEL": 35,
+            "MIN_LEVEL": 90,
             "MIN": 36.0,
-            "MAX": 65.0,
+            "MAX": 69.6,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.087,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 44.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": -1
           }
         ]
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
+        "MIN": 1.0,
         "MAX": 3.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": 50,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       }
     ],
-    "thermal:blitz": [
+    "the_vault:t2_cave_skeleton": [
       {
         "NAME": "minecraft:generic.max_health",
+        "MIN": 40.0,
+        "MAX": 60.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 80,
         "LEVELS": [
           {
-            "MIN_LEVEL": 0,
-            "MIN": 30.0,
-            "MAX": 60.0,
+            "MIN_LEVEL": 80,
+            "MIN": 44.0,
+            "MAX": 66.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
+            "SCALE_MAX_LEVEL": -1
           },
           {
-            "MIN_LEVEL": 35,
-            "MIN": 36.0,
-            "MAX": 65.0,
+            "MIN_LEVEL": 90,
+            "MIN": 48.0,
+            "MAX": 72.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.087,
-            "SCALE_MAX_LEVEL": 64
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
           },
           {
-            "MIN_LEVEL": 65,
-            "MIN": 44.0,
-            "MAX": 75.0,
+            "MIN_LEVEL": 80,
+            "MIN": 52.800000000000004,
+            "MAX": 79.2,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 57.599999999999994,
+            "MAX": 86.39999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": -1
           }
         ]
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
+        "MIN": 1.0,
         "MAX": 3.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": 80,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       }
     ],
-    "thermal:basalz": [
+    "the_vault:t3_cave_skeleton": [
       {
         "NAME": "minecraft:generic.max_health",
+        "MIN": 55.0,
+        "MAX": 80.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1,
         "LEVELS": [
           {
-            "MIN_LEVEL": 0,
-            "MIN": 30.0,
-            "MAX": 60.0,
+            "MIN_LEVEL": 80,
+            "MIN": 60.50000000000001,
+            "MAX": 88.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
+            "SCALE_MAX_LEVEL": -1
           },
           {
-            "MIN_LEVEL": 35,
-            "MIN": 36.0,
-            "MAX": 65.0,
+            "MIN_LEVEL": 90,
+            "MIN": 66.0,
+            "MAX": 96.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.087,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 44.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -8295,60 +3252,150 @@
       {
         "NAME": "minecraft:generic.attack_damage",
         "MIN": 2.0,
-        "MAX": 3.0,
+        "MAX": 4.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.2,
+            "MAX": 4.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2.4,
+            "MAX": 4.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       }
     ],
-    "alexsmobs:guster": [
+    "the_vault:t4_cave_skeleton": [
       {
         "NAME": "minecraft:generic.max_health",
+        "MIN": 55.0,
+        "MAX": 80.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1,
         "LEVELS": [
           {
-            "MIN_LEVEL": 0,
-            "MIN": 30.0,
-            "MAX": 60.0,
+            "MIN_LEVEL": 80,
+            "MIN": 60.50000000000001,
+            "MAX": 88.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
+            "SCALE_MAX_LEVEL": -1
           },
           {
-            "MIN_LEVEL": 35,
-            "MIN": 36.0,
-            "MAX": 65.0,
+            "MIN_LEVEL": 90,
+            "MIN": 66.0,
+            "MAX": 96.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.087,
-            "SCALE_MAX_LEVEL": 64
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
           },
           {
-            "MIN_LEVEL": 65,
-            "MIN": 44.0,
-            "MAX": 75.0,
+            "MIN_LEVEL": 80,
+            "MIN": 72.60000000000001,
+            "MAX": 105.60000000000001,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 79.2,
+            "MAX": 115.19999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -8356,29 +3403,255 @@
       {
         "NAME": "minecraft:generic.attack_damage",
         "MIN": 2.0,
-        "MAX": 3.0,
+        "MAX": 4.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.2,
+            "MAX": 4.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2.4,
+            "MAX": 4.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t5_cave_skeleton": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 55.0,
+        "MAX": 80.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 60.50000000000001,
+            "MAX": 88.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 66.0,
+            "MAX": 96.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 72.60000000000001,
+            "MAX": 105.60000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 79.2,
+            "MAX": 115.19999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.2,
+            "MAX": 4.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2.4,
+            "MAX": 4.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "minecraft:blaze": [
@@ -8442,7 +3715,7 @@
         "SCALE_MAX_LEVEL": 50
       }
     ],
-    "alexsmobs:orca": [
+    "the_vault:vault_wraith_white": [
       {
         "NAME": "minecraft:generic.max_health",
         "LEVELS": [
@@ -8457,338 +3730,53 @@
           },
           {
             "MIN_LEVEL": 35,
-            "MIN": 80.0,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 60.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 66.0,
+            "MAX": 82.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 72.0,
             "MAX": 90.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
+            "SCALE_MAX_LEVEL": -1
           },
           {
-            "MIN_LEVEL": 65,
-            "MIN": 91.0,
-            "MAX": 102.0,
+            "MIN_LEVEL": 80,
+            "MIN": 79.2,
+            "MAX": 99.00000000000001,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
             "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 4.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
           },
           {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      }
-    ],
-    "alexsmobs:frilled_shark": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 60.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      }
-    ],
-    "minecraft:guardian": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 60.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.056,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      }
-    ],
-    "quark:wraith": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 30.0,
-            "MAX": 55.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 60.0,
-            "MAX": 75.0,
+            "MIN_LEVEL": 90,
+            "MIN": 86.39999999999999,
+            "MAX": 108.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
@@ -8803,7 +3791,27 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -10437,44 +5445,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "tropicraft:tropicreeper": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.03,
-        "MAX": 1.06,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 80
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 28.0,
-        "MAX": 42.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.4,
-        "MAX": 2.4,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 7.0,
-        "MAX": 7.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "the_vault:t3_creeper": [
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -10502,104 +5472,6 @@
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
         "SCALE_MAX_LEVEL": 80
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "grimoireofgaia:harpy": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.125,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.125,
-            "MAX": 0.175,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.175,
-            "MAX": 0.225,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.6,
-            "MAX": 1.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.8,
-            "MAX": 1.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 5.0,
-        "MAX": 7.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 70.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          }
-        ]
       },
       {
         "NAME": "forge:swim_speed",
@@ -10719,131 +5591,6 @@
             "MIN_LEVEL": 90,
             "MIN": 35.0,
             "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "tropicraft:tropi_spider": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.07,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.17,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.22,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.75,
-            "MAX": 1.75,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 2.0,
-            "MAX": 2.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 2.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 30.0,
-            "MAX": 35.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 60.0,
-            "MAX": 67.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 65.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 85.0,
-            "MAX": 93.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -11094,6 +5841,94 @@
             "MIN_LEVEL": 90,
             "MIN": 85.0,
             "MAX": 99.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "minecraft:slime": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.15,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 8.0,
+            "MAX": 12.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 14.0,
+            "MAX": 32.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 26.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 28.6,
+            "MAX": 44.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 31.2,
+            "MAX": 48.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 34.32,
+            "MAX": 52.800000000000004,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 37.44,
+            "MAX": 57.599999999999994,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -11483,6 +6318,240 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
+    "the_vault:raised_zombie": [
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.65,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 1.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.2,
+        "MAX": 0.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.5,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.5,
+            "MAX": 2.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 3.0,
+            "MAX": 3.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 15.0,
+            "MAX": 25.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 25.0,
+            "MAX": 30.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 30.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 40.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.0,
+        "MAX": 1.1,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:raised_zombie_chicken": [
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.65,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 1.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.2,
+        "MAX": 0.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.5,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.5,
+            "MAX": 2.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 3.0,
+            "MAX": 3.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 5.0,
+            "MAX": 10.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 10.0,
+            "MAX": 15.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 15.0,
+            "MAX": 20.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 20.0,
+            "MAX": 25.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.2,
+        "MAX": 1.3,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
     "auxiliaryblocks:gingerbread_man_giant": [
       {
         "NAME": "minecraft:generic.knockback_resistance",
@@ -11658,6 +6727,123 @@
         "NAME": "minecraft:generic.movement_speed",
         "MIN": 0.9,
         "MAX": 0.95,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:scarab": [
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.65,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 1.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.5,
+        "MAX": 0.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 2.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.2,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 4.0,
+            "MAX": 5.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 5.0,
+            "MAX": 6.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 20.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 40.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 80.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 100.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.2,
+        "MAX": 1.2,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -14145,1769 +9331,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "the_vault:t1_plastic_zombie": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.14,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.12,
-            "MAX": 0.18,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.35,
-            "MAX": 1.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 24.0,
-        "MAX": 29.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 26.400000000000002,
-            "MAX": 31.900000000000002,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 28.799999999999997,
-            "MAX": 34.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 31.68,
-            "MAX": 38.28,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 34.559999999999995,
-            "MAX": 41.76,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t2_plastic_zombie": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.14,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.12,
-            "MAX": 0.18,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.35,
-            "MAX": 1.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 38.0,
-        "MAX": 50.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 41.800000000000004,
-            "MAX": 55.00000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 45.6,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 50.160000000000004,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 54.72,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t3_plastic_zombie": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.14,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.12,
-            "MAX": 0.18,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.35,
-            "MAX": 1.35,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 90,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 50.0,
-        "MAX": 65.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 55.00000000000001,
-            "MAX": 71.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 60.0,
-            "MAX": 78.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 66.0,
-            "MAX": 85.80000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 72.0,
-            "MAX": 93.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t4_plastic_zombie": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 70.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 77.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 84.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 92.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 100.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t1_plastic_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 30.0,
-        "MAX": 58.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 33.0,
-            "MAX": 63.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 36.0,
-            "MAX": 69.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t2_plastic_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 40.0,
-        "MAX": 60.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 44.0,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 48.0,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 52.800000000000004,
-            "MAX": 79.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 57.599999999999994,
-            "MAX": 86.39999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t3_plastic_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 80.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t4_plastic_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 80.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t5_plastic_skeleton": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 55.0,
-        "MAX": 80.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t1_plastic_slime": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.15,
-        "MAX": 1.15,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 8.0,
-            "MAX": 12.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 14.0,
-            "MAX": 32.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 26.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 28.6,
-            "MAX": 44.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 31.2,
-            "MAX": 48.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 34.32,
-            "MAX": 52.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 37.44,
-            "MAX": 57.599999999999994,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t2_plastic_slime": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.17,
-        "MAX": 1.17,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 16.0,
-            "MAX": 24.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 28.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 41.0,
-            "MAX": 50.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 51.6,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 61.2,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 76.32,
-            "MAX": 82.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 83.44,
-            "MAX": 90.599999999999994,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t3_plastic_slime": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.2,
-        "MAX": 1.2,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 24.0,
-            "MAX": 36.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 37.0,
-            "MAX": 45.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 46.0,
-            "MAX": 56.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 57.6,
-            "MAX": 67.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 68.2,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 81.32,
-            "MAX": 95.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 96.44,
-            "MAX": 110.599999999999994,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:t4_plastic_slime": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.3,
-        "MAX": 1.3,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 40.0,
-            "MAX": 50.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 51.0,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 61.0,
-            "MAX": 70.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 71.6,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 81.2,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 91.32,
-            "MAX": 100.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 101.44,
-            "MAX": 130.599999999999994,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "minecraft:slime": [
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.15,
-        "MAX": 1.15,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 8.0,
-            "MAX": 12.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 14.0,
-            "MAX": 32.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 26.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 28.6,
-            "MAX": 44.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 31.2,
-            "MAX": 48.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 34.32,
-            "MAX": 52.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 37.44,
-            "MAX": 57.599999999999994,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "the_vault:vault_guardian": [
       {
         "NAME": "forge:swim_speed",
@@ -15973,431 +9396,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "the_vault:wold": [
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.65,
-        "MAX": 1.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.05,
-        "MAX": 0.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.5,
-        "MAX": 2.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 8.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 800.0,
-        "MAX": 1200.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.14,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.0,
-        "MAX": 1.25,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.indirect_tp_chance",
-        "MIN": 0.25,
-        "MAX": 0.60,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.tp_range",
-        "MIN": 4.0,
-        "MAX": 16.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-   "the_vault:golem_boss": [
-            {
-                "NAME": "minecraft:generic.knockback_resistance",
-                "MIN": 0.65,
-                "MAX": 1.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 1.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "the_vault:generic.crit_chance",
-                "MIN": 0.0,
-                "MAX": 0.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "the_vault:generic.crit_multiplier",
-                "MIN": 1.5,
-                "MAX": 1.8,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "minecraft:generic.attack_damage",
-                "MIN": 2.0,
-                "MAX": 4.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.1,
-                "SCALE_MAX_LEVEL": -1,
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 2.1,
-                        "MAX": 4.6,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.1,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 2.2,
-                        "MAX": 5.2,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.1,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.max_health",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 400.0,
-                        "MAX": 600.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.067,
-                        "SCALE_MAX_LEVEL": 49
-                    },
-                    {
-                        "MIN_LEVEL": 50,
-                        "MIN": 800.0,
-                        "MAX": 1200.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 1400.0,
-                        "MAX": 2000.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 2400.0,
-                        "MAX": 3000.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.movement_speed",
-                "MIN": 1.0,
-                "MAX": 1.1,
-                "OPERATOR": "multiply",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "forge:swim_speed",
-                "MIN": 5.0,
-                "MAX": 5.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            }
-        ],
-        "the_vault:boogieman_boss": [
-            {
-                "NAME": "minecraft:generic.knockback_resistance",
-                "MIN": 0.65,
-                "MAX": 1.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 1.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "the_vault:generic.crit_chance",
-                "MIN": 0.1,
-                "MAX": 0.1,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "the_vault:generic.crit_multiplier",
-                "MIN": 1.5,
-                "MAX": 1.8,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "minecraft:generic.attack_damage",
-                "MIN": 3.0,
-                "MAX": 5.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.1,
-                "SCALE_MAX_LEVEL": -1,
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 2.1,
-                        "MAX": 4.6,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.1,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 2.2,
-                        "MAX": 5.2,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.1,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.max_health",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 200.0,
-                        "MAX": 400.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.067,
-                        "SCALE_MAX_LEVEL": 49
-                    },
-                    {
-                        "MIN_LEVEL": 50,
-                        "MIN": 600.0,
-                        "MAX": 800.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 1000.0,
-                        "MAX": 1400.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 1400.0,
-                        "MAX": 2200.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.movement_speed",
-                "MIN": 1.05,
-                "MAX": 1.1,
-                "OPERATOR": "multiply",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "forge:swim_speed",
-                "MIN": 5.0,
-                "MAX": 5.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            }
-        ],
-        "the_vault:black_widow_boss": [
-            {
-                "NAME": "minecraft:generic.knockback_resistance",
-                "MIN": 0.65,
-                "MAX": 1.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 1.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "the_vault:generic.crit_chance",
-                "MIN": 0.5,
-                "MAX": 0.5,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "the_vault:generic.crit_multiplier",
-                "MIN": 2.0,
-                "MAX": 2.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "minecraft:generic.attack_damage",
-                "MIN": 1.5,
-                "MAX": 3.5,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.1,
-                "SCALE_MAX_LEVEL": -1,
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 1.6,
-                        "MAX": 4.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.1,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 1.8,
-                        "MAX": 4.4,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.1,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.max_health",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 150.0,
-                        "MAX": 300.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.067,
-                        "SCALE_MAX_LEVEL": 49
-                    },
-                    {
-                        "MIN_LEVEL": 50,
-                        "MIN": 400.0,
-                        "MAX": 600.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 800.0,
-                        "MAX": 1000.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 1000.0,
-                        "MAX": 1600.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.movement_speed",
-                "MIN": 1.1,
-                "MAX": 1.2,
-                "OPERATOR": "multiply",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            },
-            {
-                "NAME": "forge:swim_speed",
-                "MIN": 5.0,
-                "MAX": 5.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            }
-        ],
     "the_vault:boogieman": [
       {
         "NAME": "minecraft:generic.knockback_resistance",
@@ -16815,297 +9813,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "the_vault:butcher_bruiser_guardian": [
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 1.8,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.07,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 45.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.14,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 50.0,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
-            "SCALE_MAX_LEVEL": 79
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 100.0,
-            "MAX": 180.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.reach",
-        "MIN": 2.3,
-        "MAX": 2.7,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.break_armor_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.35,
-        "MAX": 0.4,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:crystal_bruiser_guardian": [
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 1.8,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.07,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 45.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.14,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 50.0,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
-            "SCALE_MAX_LEVEL": 79
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 100.0,
-            "MAX": 180.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.reach",
-        "MIN": 2.3,
-        "MAX": 2.7,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.break_armor_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.35,
-        "MAX": 0.4,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:pirate_bruiser_guardian": [
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 1.8,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.07,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 45.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.14,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 50.0,
-            "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
-            "SCALE_MAX_LEVEL": 79
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 100.0,
-            "MAX": 180.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.reach",
-        "MIN": 2.3,
-        "MAX": 2.7,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.break_armor_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.35,
-        "MAX": 0.4,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "the_vault:bruiser_guardian": [
       {
         "NAME": "forge:swim_speed",
@@ -17291,7 +9998,7 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "the_vault:butcher_arbalist_guardian": [
+    "the_vault:crystal_bruiser_guardian": [
       {
         "NAME": "forge:swim_speed",
         "MIN": 5.0,
@@ -17299,7 +10006,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -17325,7 +10032,7 @@
         "MAX": 1.8,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_PER_LEVEL": 0.07,
         "SCALE_MAX_LEVEL": -1
       },
       {
@@ -17333,26 +10040,26 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 45.0,
+            "MIN": 45.0,
+            "MAX": 80.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_PER_LEVEL": 0.14,
             "SCALE_MAX_LEVEL": 64
           },
           {
             "MIN_LEVEL": 65,
-            "MIN": 28.0,
-            "MAX": 52.0,
+            "MIN": 50.0,
+            "MAX": 90.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_PER_LEVEL": 0.16,
             "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 50.0,
-            "MAX": 90.0,
+            "MIN": 100.0,
+            "MAX": 180.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.16,
@@ -17361,18 +10068,27 @@
         ]
       },
       {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.35,
-        "MAX": 0.35,
+        "NAME": "the_vault:generic.reach",
+        "MIN": 2.3,
+        "MAX": 2.7,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
       },
       {
-        "NAME": "the_vault:generic.crossbow_charge_time",
-        "MIN": 30.0,
-        "MAX": 70.0,
+        "NAME": "the_vault:generic.break_armor_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 0.35,
+        "MAX": 0.4,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -17467,7 +10183,289 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
+    "the_vault:pirate_bruiser_guardian": [
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.07,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 45.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.14,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 50.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 100.0,
+            "MAX": 180.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.reach",
+        "MIN": 2.3,
+        "MAX": 2.7,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.break_armor_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 0.35,
+        "MAX": 0.4,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
     "the_vault:pirate_arbalist_guardian": [
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 45.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 28.0,
+            "MAX": 52.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 50.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 0.35,
+        "MAX": 0.35,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crossbow_charge_time",
+        "MIN": 30.0,
+        "MAX": 70.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:butcher_bruiser_guardian": [
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.07,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 45.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.14,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 50.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 100.0,
+            "MAX": 180.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.reach",
+        "MIN": 2.3,
+        "MAX": 2.7,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.break_armor_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 0.35,
+        "MAX": 0.4,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:butcher_arbalist_guardian": [
       {
         "NAME": "forge:swim_speed",
         "MIN": 5.0,
@@ -17567,350 +10565,6 @@
       }
     ],
     "the_vault:crab": [
-            {
-                "NAME": "the_vault:generic.crit_chance",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 0.05,
-                        "MAX": 0.1,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": 49
-                    },
-                    {
-                        "MIN_LEVEL": 50,
-                        "MIN": 0.1,
-                        "MAX": 0.15,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": 84
-                    },
-                    {
-                        "MIN_LEVEL": 85,
-                        "MIN": 0.15,
-                        "MAX": 0.2,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "the_vault:generic.crit_multiplier",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 1.2,
-                        "MAX": 1.2,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": 49
-                    },
-                    {
-                        "MIN_LEVEL": 50,
-                        "MIN": 1.3,
-                        "MAX": 1.3,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": 84
-                    },
-                    {
-                        "MIN_LEVEL": 85,
-                        "MIN": 1.4,
-                        "MAX": 1.4,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.attack_damage",
-                "MIN": 1.2,
-                "MAX": 1.6,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.08,
-                "SCALE_MAX_LEVEL": -1,
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 1.32,
-                        "MAX": 1.7600000000000002,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.08,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 1.44,
-                        "MAX": 1.92,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.08,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.max_health",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 20.0,
-                        "MAX": 28.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.09,
-                        "SCALE_MAX_LEVEL": 49
-                    },
-                    {
-                        "MIN_LEVEL": 50,
-                        "MIN": 38.0,
-                        "MAX": 52.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.09,
-                        "SCALE_MAX_LEVEL": 64
-                    },
-                    {
-                        "MIN_LEVEL": 65,
-                        "MIN": 43.0,
-                        "MAX": 60.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.09,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 47.300000000000004,
-                        "MAX": 66.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.09,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 51.6,
-                        "MAX": 72.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.09,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 56.760000000000005,
-                        "MAX": 79.2,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.09,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 61.92,
-                        "MAX": 86.39999999999999,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.09,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "forge:swim_speed",
-                "MIN": 5.0,
-                "MAX": 5.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            }
-        ],
-        "the_vault:vault_wraith_white": [
-            {
-                "NAME": "minecraft:generic.max_health",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 20.0,
-                        "MAX": 40.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.067,
-                        "SCALE_MAX_LEVEL": 34
-                    },
-                    {
-                        "MIN_LEVEL": 35,
-                        "MIN": 30.0,
-                        "MAX": 55.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": 64
-                    },
-                    {
-                        "MIN_LEVEL": 65,
-                        "MIN": 60.0,
-                        "MAX": 75.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 66.0,
-                        "MAX": 82.5,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 72.0,
-                        "MAX": 90.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 79.2,
-                        "MAX": 99.00000000000001,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 86.39999999999999,
-                        "MAX": 108.0,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.077,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "minecraft:generic.attack_damage",
-                "MIN": 1.0,
-                "MAX": 3.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.1,
-                "SCALE_MAX_LEVEL": -1,
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 80,
-                        "MIN": 1.1,
-                        "MAX": 3.3000000000000003,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.1,
-                        "SCALE_MAX_LEVEL": -1
-                    },
-                    {
-                        "MIN_LEVEL": 90,
-                        "MIN": 1.2,
-                        "MAX": 3.5999999999999996,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.1,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "the_vault:generic.crit_chance",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 0.05,
-                        "MAX": 0.1,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": 49
-                    },
-                    {
-                        "MIN_LEVEL": 50,
-                        "MIN": 0.1,
-                        "MAX": 0.15,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": 84
-                    },
-                    {
-                        "MIN_LEVEL": 85,
-                        "MIN": 0.15,
-                        "MAX": 0.2,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "the_vault:generic.crit_multiplier",
-                "LEVELS": [
-                    {
-                        "MIN_LEVEL": 0,
-                        "MIN": 1.2,
-                        "MAX": 1.2,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": 49
-                    },
-                    {
-                        "MIN_LEVEL": 50,
-                        "MIN": 1.3,
-                        "MAX": 1.3,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": 84
-                    },
-                    {
-                        "MIN_LEVEL": 85,
-                        "MIN": 1.4,
-                        "MAX": 1.4,
-                        "OPERATOR": "set",
-                        "ROLL_CHANCE": 1.0,
-                        "SCALE_PER_LEVEL": 0.0,
-                        "SCALE_MAX_LEVEL": -1
-                    }
-                ]
-            },
-            {
-                "NAME": "forge:swim_speed",
-                "MIN": 5.0,
-                "MAX": 5.0,
-                "OPERATOR": "set",
-                "ROLL_CHANCE": 1.0,
-                "SCALE_PER_LEVEL": 0.0,
-                "SCALE_MAX_LEVEL": -1
-            }
-        ],
-    "ecologics:coconut_crab": [
       {
         "NAME": "the_vault:generic.crit_chance",
         "LEVELS": [
@@ -17982,7 +10636,27 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": -1
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.32,
+            "MAX": 1.7600000000000002,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.44,
+            "MAX": 1.92,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -18009,6 +10683,42 @@
             "MIN_LEVEL": 65,
             "MIN": 43.0,
             "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 47.300000000000004,
+            "MAX": 66.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 51.6,
+            "MAX": 72.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 56.760000000000005,
+            "MAX": 79.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 61.92,
+            "MAX": 86.39999999999999,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -18175,11 +10885,11 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "alexsmobs:alligator_snapping_turtle": [
+    "the_vault:levishroom": [
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.1,
-        "MAX": 0.1,
+        "MIN": 0.3,
+        "MAX": 0.3,
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
@@ -18196,8 +10906,8 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 2.0,
+        "MIN": 0.5,
+        "MAX": 0.7,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
@@ -18208,8 +10918,8 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 10.0,
-            "MAX": 18.0,
+            "MIN": 20.0,
+            "MAX": 30.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -18217,8 +10927,8 @@
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 24.0,
-            "MAX": 32.0,
+            "MIN": 33.0,
+            "MAX": 44.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -18226,8 +10936,17 @@
           },
           {
             "MIN_LEVEL": 65,
-            "MIN": 30.0,
-            "MAX": 46.0,
+            "MIN": 50.0,
+            "MAX": 65.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 65.0,
+            "MAX": 85.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -18238,7 +10957,7 @@
       {
         "NAME": "minecraft:generic.movement_speed",
         "MIN": 1.0,
-        "MAX": 1.2,
+        "MAX": 1.0,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -18532,123 +11251,6 @@
         "MIN": 0.33,
         "MAX": 0.5,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:scarab": [
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.65,
-        "MAX": 1.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 1.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.5,
-        "MAX": 0.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 2.0,
-        "MAX": 2.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.2,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 4.0,
-            "MAX": 5.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.2,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 5.0,
-            "MAX": 6.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.2,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 20.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 40.0,
-            "MAX": 40.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 80.0,
-            "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 100.0,
-            "MAX": 100.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.2,
-        "MAX": 1.2,
-        "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
@@ -19641,6 +12243,251 @@
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.1,
         "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:healer": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.0,
+            "MAX": 0.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.0,
+            "MAX": 0.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.0,
+            "MAX": 0.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.heal_amount",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 8.0,
+            "MAX": 12.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 12.0,
+            "MAX": 20.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 16.0,
+            "MAX": 28.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 20.0,
+            "MAX": 36.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.11,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.heal_range",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 15.0,
+            "MAX": 15.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 20.0,
+            "MAX": 20.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 24.0,
+            "MAX": 24.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 32.0,
+            "MAX": 32.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.4,
+        "MAX": 1.9,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.54,
+            "MAX": 2.09,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.68,
+            "MAX": 2.28,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 22.0,
+            "MAX": 28.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.07,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 30.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 40.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.11,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 58.0,
+            "MAX": 78.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.11,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 62.0,
+            "MAX": 88.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.11,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.0,
+        "MAX": 1.0,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -21036,14 +13883,14 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "grimoireofgaia:goblin_feral": [
+    "the_vault:blood_horde_t1": [
       {
         "NAME": "the_vault:generic.crit_chance",
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 0.075,
-            "MAX": 0.125,
+            "MIN": 0.05,
+            "MAX": 0.1,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.0,
@@ -21051,8 +13898,8 @@
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 0.125,
-            "MAX": 0.175,
+            "MIN": 0.1,
+            "MAX": 0.14,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.0,
@@ -21060,8 +13907,488 @@
           },
           {
             "MIN_LEVEL": 85,
-            "MIN": 0.175,
-            "MAX": 0.225,
+            "MIN": 0.12,
+            "MAX": 0.18,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.35,
+            "MAX": 1.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": 50,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 24.0,
+        "MAX": 29.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 50,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 26.400000000000002,
+            "MAX": 31.900000000000002,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 28.799999999999997,
+            "MAX": 34.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 31.68,
+            "MAX": 38.28,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 34.559999999999995,
+            "MAX": 41.76,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:blood_horde_t2": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.14,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.12,
+            "MAX": 0.18,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.35,
+            "MAX": 1.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.01,
+        "SCALE_MAX_LEVEL": 80,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.01,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.01,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 38.0,
+        "MAX": 50.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 80,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 41.800000000000004,
+            "MAX": 55.00000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 45.6,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 50.160000000000004,
+            "MAX": 66.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 54.72,
+            "MAX": 72.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:blood_horde_t3": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.14,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.12,
+            "MAX": 0.18,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.35,
+            "MAX": 1.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.015,
+        "SCALE_MAX_LEVEL": 90,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.015,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.015,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 50.0,
+        "MAX": 65.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 90,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 55.00000000000001,
+            "MAX": 71.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 60.0,
+            "MAX": 78.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 66.0,
+            "MAX": 85.80000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 72.0,
+            "MAX": 93.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:blood_horde_t4": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.0,
@@ -21103,27 +14430,254 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 5.0,
+        "MIN": 1.0,
+        "MAX": 3.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.018,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_PER_LEVEL": 0.015,
+        "SCALE_MAX_LEVEL": 100,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.015,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.015,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 80.0,
-        "MAX": 90.0,
+        "MIN": 55.0,
+        "MAX": 70.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": 100,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 60.50000000000001,
+            "MAX": 77.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 66.0,
+            "MAX": 84.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 72.60000000000001,
+            "MAX": 92.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 79.2,
+            "MAX": 100.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "forge:swim_speed",
         "MIN": 5.0,
         "MAX": 5.0,
         "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:blood_horde_t5": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.018,
+        "SCALE_MAX_LEVEL": 100,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.018,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.018,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 70.0,
+        "MAX": 80.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 100,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 77.0,
+            "MAX": 88.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 84.0,
+            "MAX": 96.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 92.4,
+            "MAX": 105.60000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 100.8,
+            "MAX": 115.19999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
@@ -24129,182 +17683,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "the_vault:levishroom": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.3,
-        "MAX": 0.3,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.4,
-        "MAX": 1.4,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 0.5,
-        "MAX": 0.7,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 30.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 33.0,
-            "MAX": 44.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 50.0,
-            "MAX": 65.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 65.0,
-            "MAX": 85.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.0,
-        "MAX": 1.0,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "tropicraft:ashen": [
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.3,
-        "MAX": 0.3,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.4,
-        "MAX": 1.4,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 0.5,
-        "MAX": 0.7,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 30.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 33.0,
-            "MAX": 44.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 64
-          },
-          {
-            "MIN_LEVEL": 65,
-            "MIN": 50.0,
-            "MAX": 65.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 65.0,
-            "MAX": 85.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.0,
-        "MAX": 1.0,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "the_vault:blood_slime": [
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -25005,108 +18383,6 @@
         "SCALE_MAX_LEVEL": -1
       }
     ],
-    "grimoireofgaia:bone_knight": [
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 100.0,
-        "MAX": 130.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 5.0,
-        "MAX": 7.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.038,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.7,
-        "MAX": 0.9,
-        "OPERATOR": "multiply",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.15,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.2,
-            "MAX": 0.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.5,
-            "MAX": 1.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.75,
-            "MAX": 1.75,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
     "the_vault:blood_silverfish": [
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -25218,6 +18494,7209 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:golem_boss": [
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.65,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 1.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.5,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.1,
+            "MAX": 4.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2.2,
+            "MAX": 5.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 400.0,
+            "MAX": 600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 800.0,
+            "MAX": 1200.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1400.0,
+            "MAX": 2000.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2400.0,
+            "MAX": 3000.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.0,
+        "MAX": 1.1,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:boogieman_boss": [
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.65,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 1.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.1,
+        "MAX": 0.1,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.5,
+        "MAX": 1.8,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.1,
+            "MAX": 4.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2.2,
+            "MAX": 5.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 200.0,
+            "MAX": 400.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 600.0,
+            "MAX": 800.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1000.0,
+            "MAX": 1400.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1400.0,
+            "MAX": 2200.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.1,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:black_widow_boss": [
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.65,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 1.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.5,
+        "MAX": 0.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 2.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.5,
+        "MAX": 3.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.6,
+            "MAX": 4.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.8,
+            "MAX": 4.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 150.0,
+            "MAX": 300.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 400.0,
+            "MAX": 600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 800.0,
+            "MAX": 1000.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1000.0,
+            "MAX": 1600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.1,
+        "MAX": 1.2,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:wold": [
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.65,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.05,
+        "MAX": 0.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.01,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.5,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.01,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 8.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 800.0,
+        "MAX": 1200.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.14,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.0,
+        "MAX": 1.25,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.01,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.indirect_tp_chance",
+        "MIN": 0.25,
+        "MAX": 0.60,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.tp_range",
+        "MIN": 4.0,
+        "MAX": 16.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:swamp_zombie": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_MAX_LEVEL": 75,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 41.0,
+        "MAX": 60.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 75,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 45.1,
+            "MAX": 66.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 49.199999999999996,
+            "MAX": 72.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 54.12,
+            "MAX": 79.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 59.03999999999999,
+            "MAX": 86.39999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:black_ghost": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 75.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.07,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:blue_ghost": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 60.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.07,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:brown_ghost": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 0.75,
+        "MAX": 1.0,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 90.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.085,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 6.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:dark_blue_ghost": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.1,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 80.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 6.0,
+        "MAX": 6.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.75,
+            "MAX": 1.75,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:dark_red_ghost": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.1,
+        "MAX": 1.1,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 150.0,
+            "MAX": 150.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 4.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.2,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:dark_gray_ghost": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 60.0,
+            "MAX": 110.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 120.0,
+            "MAX": 150.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.065,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 6.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.2,
+            "MAX": 0.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:green_ghost": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 75.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.07,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:purple_ghost": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.05,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 60.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 100.0,
+            "MAX": 110.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.07,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 4.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:red_ghost": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 100.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 125.0,
+            "MAX": 125.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.2,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "woldsvaults:yellow_ghost": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.25,
+        "MAX": 1.5,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 20
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 50.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.065,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.15,
+            "MAX": 0.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:mungus": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 12.0,
+            "MAX": 16.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 17.0,
+            "MAX": 20.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 21.0,
+            "MAX": 25.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 25.0,
+            "MAX": 28.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 29.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:void_worm": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 36.0,
+            "MAX": 54.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 55.0,
+            "MAX": 70.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 71.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 81.0,
+            "MAX": 110.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 111.0,
+            "MAX": 135.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:enderiophage": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 36.0,
+            "MAX": 54.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 55.0,
+            "MAX": 70.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 71.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 81.0,
+            "MAX": 110.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 111.0,
+            "MAX": 135.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:komodo_dragon": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 28.0,
+            "MAX": 48.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 49.0,
+            "MAX": 69.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 70.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 91.0,
+            "MAX": 101.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 102.0,
+            "MAX": 111.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:snow_leopard": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.2,
+            "MAX": 0.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.25,
+            "MAX": 0.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.6,
+            "MAX": 1.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 18.0,
+            "MAX": 30.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 31.0,
+            "MAX": 39.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 40.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 61.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 76.0,
+            "MAX": 83.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:dropbear": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.2,
+            "MAX": 0.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.25,
+            "MAX": 0.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.6,
+            "MAX": 1.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 18.0,
+            "MAX": 30.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 31.0,
+            "MAX": 39.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 40.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 61.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 76.0,
+            "MAX": 83.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:tiger": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.2,
+            "MAX": 0.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.25,
+            "MAX": 0.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.6,
+            "MAX": 1.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 18.0,
+            "MAX": 30.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 31.0,
+            "MAX": 39.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 40.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 61.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 76.0,
+            "MAX": 83.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:gorilla": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 36.0,
+            "MAX": 54.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 55.0,
+            "MAX": 70.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 71.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 81.0,
+            "MAX": 110.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 111.0,
+            "MAX": 135.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:crocodile": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.15,
+            "MAX": 0.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.3,
+            "MAX": 0.45,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.4,
+            "MAX": 1.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.6,
+            "MAX": 2.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 22.0,
+            "MAX": 30.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 45.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 46.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 55.0,
+            "MAX": 70.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 71.0,
+            "MAX": 95.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:aggressive_cow": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 22.0,
+            "MAX": 30.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 31.0,
+            "MAX": 45.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 46.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 61.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 81.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:aggressive_cow_boss": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.15,
+            "MAX": 0.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.01,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.2,
+            "MAX": 0.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.25,
+            "MAX": 0.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.8,
+            "MAX": 1.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 4.0,
+        "MAX": 7.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 60.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 100.0,
+            "MAX": 120.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 130.0,
+            "MAX": 160.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 200.0,
+            "MAX": 220.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 240.0,
+            "MAX": 300.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "cloudstorage:bloviator": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 18.0,
+            "MAX": 24.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 25.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 41.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 61.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 81.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:centipede_head": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 52.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 50.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 70.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 90.0,
+            "MAX": 130.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 120.0,
+            "MAX": 170.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.5,
+        "MAX": 2.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.03,
+            "MAX": 0.07,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.07,
+            "MAX": 0.10,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.1,
+        "MAX": 1.2,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "grimoireofgaia:minotaur": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.25,
+            "MAX": 0.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.5,
+            "MAX": 2.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 8.0,
+        "MAX": 8.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 110.0,
+        "MAX": 135.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 0.24,
+        "MAX": 0.24,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.25,
+        "MAX": 0.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "grimoireofgaia:minotaurus": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.5,
+            "MAX": 2.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 8.0,
+        "MAX": 9.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 90.0,
+        "MAX": 110.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 0.32,
+        "MAX": 0.32,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.25,
+        "MAX": 0.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "tropicraft:eih": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 4.0,
+        "MAX": 6.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 68.0,
+            "MAX": 82.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 80.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 100.0,
+            "MAX": 130.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 140.0,
+            "MAX": 170.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 170.0,
+            "MAX": 200.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.7,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "grimoireofgaia:cobble_golem": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 40.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 60.0,
+            "MAX": 70.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 70.0,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 80.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 90.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.7,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "grimoireofgaia:cobblestone_golem": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.25,
+        "MAX": 0.25,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.5,
+        "MAX": 1.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 4.0,
+        "MAX": 8.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.25,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 80.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 100.0,
+            "MAX": 120.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 120.0,
+            "MAX": 140.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 140.0,
+            "MAX": 160.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 160.0,
+            "MAX": 200.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.7,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "grimoireofgaia:flesh_lich": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.1,
+        "MAX": 0.1,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.5,
+        "MAX": 1.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 4.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 40.0,
+            "MAX": 50.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 59.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 87.0,
+            "MAX": 114.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 102.0,
+            "MAX": 144.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 125.0,
+            "MAX": 184.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 0.33,
+        "MAX": 0.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "tropicraft:tropiskelly": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 55.0,
+        "MAX": 80.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "thermal:blizz": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 30.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 36.0,
+            "MAX": 65.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 44.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": 50
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 50
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 50
+      }
+    ],
+    "thermal:blitz": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 30.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 36.0,
+            "MAX": 65.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 44.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": 50
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 50
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 50
+      }
+    ],
+    "thermal:basalz": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 30.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 36.0,
+            "MAX": 65.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 44.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": 50
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 50
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 50
+      }
+    ],
+    "alexsmobs:guster": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 30.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 36.0,
+            "MAX": 65.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 44.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": 50
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 50
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 50
+      }
+    ],
+    "alexsmobs:orca": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 80.0,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 91.0,
+            "MAX": 102.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 4.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      }
+    ],
+    "alexsmobs:frilled_shark": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 60.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      }
+    ],
+    "minecraft:guardian": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 60.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.056,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      }
+    ],
+    "quark:wraith": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 30.0,
+            "MAX": 55.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 60.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "tropicraft:tropicreeper": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.03,
+        "MAX": 1.06,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": 80
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 28.0,
+        "MAX": 42.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 80
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.4,
+        "MAX": 2.4,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": 80
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 7.0,
+        "MAX": 7.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "grimoireofgaia:harpy": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.125,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.125,
+            "MAX": 0.175,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.175,
+            "MAX": 0.225,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.6,
+            "MAX": 1.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.8,
+            "MAX": 1.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 5.0,
+        "MAX": 7.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 70.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "tropicraft:tropi_spider": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.07,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.17,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.22,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.75,
+            "MAX": 1.75,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 2.0,
+            "MAX": 2.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 2.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 30.0,
+            "MAX": 35.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 60.0,
+            "MAX": 67.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 65.0,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 85.0,
+            "MAX": 93.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t1_plastic_zombie": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.14,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.12,
+            "MAX": 0.18,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.35,
+            "MAX": 1.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": 50,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 24.0,
+        "MAX": 29.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 50,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 26.400000000000002,
+            "MAX": 31.900000000000002,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 28.799999999999997,
+            "MAX": 34.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 31.68,
+            "MAX": 38.28,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 34.559999999999995,
+            "MAX": 41.76,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t2_plastic_zombie": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.14,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.12,
+            "MAX": 0.18,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.35,
+            "MAX": 1.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.01,
+        "SCALE_MAX_LEVEL": 80,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.01,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.01,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 38.0,
+        "MAX": 50.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 80,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 41.800000000000004,
+            "MAX": 55.00000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 45.6,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 50.160000000000004,
+            "MAX": 66.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 54.72,
+            "MAX": 72.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t3_plastic_zombie": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.14,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.12,
+            "MAX": 0.18,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.35,
+            "MAX": 1.35,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.015,
+        "SCALE_MAX_LEVEL": 90,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.015,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.015,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 50.0,
+        "MAX": 65.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 90,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 55.00000000000001,
+            "MAX": 71.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 60.0,
+            "MAX": 78.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 66.0,
+            "MAX": 85.80000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 72.0,
+            "MAX": 93.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t4_plastic_zombie": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.015,
+        "SCALE_MAX_LEVEL": 100,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.015,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.015,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 55.0,
+        "MAX": 70.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 100,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 60.50000000000001,
+            "MAX": 77.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 66.0,
+            "MAX": 84.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 72.60000000000001,
+            "MAX": 92.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 79.2,
+            "MAX": 100.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t1_plastic_skeleton": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 30.0,
+        "MAX": 58.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 50,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 33.0,
+            "MAX": 63.800000000000004,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 36.0,
+            "MAX": 69.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": 50,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t2_plastic_skeleton": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 40.0,
+        "MAX": 60.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 80,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 44.0,
+            "MAX": 66.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 48.0,
+            "MAX": 72.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 52.800000000000004,
+            "MAX": 79.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 57.599999999999994,
+            "MAX": 86.39999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 3.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": 80,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 1.1,
+            "MAX": 3.3000000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 1.2,
+            "MAX": 3.5999999999999996,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t3_plastic_skeleton": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 55.0,
+        "MAX": 80.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 60.50000000000001,
+            "MAX": 88.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 66.0,
+            "MAX": 96.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.2,
+            "MAX": 4.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2.4,
+            "MAX": 4.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t4_plastic_skeleton": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 55.0,
+        "MAX": 80.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 60.50000000000001,
+            "MAX": 88.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 66.0,
+            "MAX": 96.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 72.60000000000001,
+            "MAX": 105.60000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 79.2,
+            "MAX": 115.19999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.2,
+            "MAX": 4.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2.4,
+            "MAX": 4.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t5_plastic_skeleton": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 55.0,
+        "MAX": 80.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 60.50000000000001,
+            "MAX": 88.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 66.0,
+            "MAX": 96.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 72.60000000000001,
+            "MAX": 105.60000000000001,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 79.2,
+            "MAX": 115.19999999999999,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 2.0,
+        "MAX": 4.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.03,
+        "SCALE_MAX_LEVEL": -1,
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 2.2,
+            "MAX": 4.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 2.4,
+            "MAX": 4.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.03,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t1_plastic_slime": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.15,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 8.0,
+            "MAX": 12.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 14.0,
+            "MAX": 32.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 26.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 28.6,
+            "MAX": 44.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 31.2,
+            "MAX": 48.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 34.32,
+            "MAX": 52.800000000000004,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 37.44,
+            "MAX": 57.599999999999994,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t2_plastic_slime": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.17,
+        "MAX": 1.17,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 16.0,
+            "MAX": 24.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 28.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 41.0,
+            "MAX": 50.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 51.6,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 61.2,
+            "MAX": 75.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 76.32,
+            "MAX": 82.800000000000004,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 83.44,
+            "MAX": 90.599999999999994,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t3_plastic_slime": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 24.0,
+            "MAX": 36.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 37.0,
+            "MAX": 45.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 46.0,
+            "MAX": 56.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 57.6,
+            "MAX": 67.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 68.2,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 81.32,
+            "MAX": 95.800000000000004,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 96.44,
+            "MAX": 110.599999999999994,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:t4_plastic_slime": [
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.3,
+        "MAX": 1.3,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 40.0,
+            "MAX": 50.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 51.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 61.0,
+            "MAX": 70.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 71.6,
+            "MAX": 80.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 81.2,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 91.32,
+            "MAX": 100.800000000000004,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 101.44,
+            "MAX": 130.599999999999994,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "ecologics:coconut_crab": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.05,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.1,
+            "MAX": 0.15,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.15,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.2,
+        "MAX": 1.6,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 28.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 38.0,
+            "MAX": 52.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 43.0,
+            "MAX": 60.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "alexsmobs:alligator_snapping_turtle": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.1,
+        "MAX": 0.1,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.4,
+        "MAX": 1.4,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.0,
+        "MAX": 2.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 10.0,
+            "MAX": 18.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 24.0,
+            "MAX": 32.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 30.0,
+            "MAX": 46.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.0,
+        "MAX": 1.2,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "grimoireofgaia:goblin_feral": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.075,
+            "MAX": 0.125,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.125,
+            "MAX": 0.175,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.175,
+            "MAX": 0.225,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.4,
+            "MAX": 1.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 3.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.018,
+        "SCALE_MAX_LEVEL": 100
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 80.0,
+        "MAX": 90.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": 100
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "tropicraft:ashen": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.3,
+        "MAX": 0.3,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 1.4,
+        "MAX": 1.4,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 0.5,
+        "MAX": 0.7,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 20.0,
+            "MAX": 30.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 33.0,
+            "MAX": 44.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 50.0,
+            "MAX": 65.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 65.0,
+            "MAX": 85.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.0,
+        "MAX": 1.0,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "grimoireofgaia:bone_knight": [
+      {
+        "NAME": "minecraft:generic.max_health",
+        "MIN": 100.0,
+        "MAX": 130.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.067,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 5.0,
+        "MAX": 7.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.038,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 0.7,
+        "MAX": 0.9,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.1,
+            "MAX": 0.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.15,
+            "MAX": 0.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 0.2,
+            "MAX": 0.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 1.3,
+            "MAX": 1.3,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 1.5,
+            "MAX": 1.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": 84
+          },
+          {
+            "MIN_LEVEL": 85,
+            "MIN": 1.75,
+            "MAX": 1.75,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
             "SCALE_MAX_LEVEL": -1
           }
         ]


### PR DESCRIPTION
⚠️ Enable `Trim whitespaces` in diff for easier reviewing.

**Description:**
* No changes to existing entities.
* Re-order existing entities to align with vanilla VH order (for easier adoption going forward):
  * First vanilla VH entities in their original order.
  * Then VW entities.
* Add missing entities:
  * `the_vault:raised_zombie`
  * `the_vault:raised_zombie_chicken`
  * `the_vault:healer`