### PR TITLE
feat/U17: vault mobs cleanup + copy-pasta fixing + re-balance

### DIFF
--- a/config/the_vault/vault_mobs.json
+++ b/config/the_vault/vault_mobs.json
@@ -1492,10 +1492,10 @@
         "NAME": "minecraft:generic.movement_speed",
         "MIN": 0.24,
         "MAX": 0.24,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4266,19 +4266,19 @@
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4313,19 +4313,19 @@
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4360,19 +4360,19 @@
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4407,19 +4407,19 @@
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -7188,10 +7188,10 @@
         "NAME": "minecraft:generic.attack_damage",
         "MIN": 1.0,
         "MAX": 3.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.1,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -18697,9 +18697,9 @@
           {
             "MIN_LEVEL": 0,
             "MIN": 400.0,
-        "MAX": 600.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
+            "MAX": 600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.06,
             "SCALE_MAX_LEVEL": 49
           },
@@ -18709,7 +18709,7 @@
             "MAX": 540.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
+            "SCALE_PER_LEVEL": 0.1,
             "SCALE_MAX_LEVEL": 79
           },
           {
@@ -18728,7 +18728,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.3,
-        "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": -1
           }
         ]
       },
@@ -18813,8 +18813,8 @@
             "MIN_LEVEL": 80,
             "MIN": 160.0,
             "MAX": 320.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.2,
             "SCALE_MAX_LEVEL": 89
           },
@@ -18825,7 +18825,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.3,
-        "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": -1
           }
         ]
       },
@@ -18910,8 +18910,8 @@
             "MIN_LEVEL": 80,
             "MIN": 121.5,
             "MAX": 243.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.2,
             "SCALE_MAX_LEVEL": 89
           },
@@ -18922,7 +18922,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.3,
-        "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": -1
           }
         ]
       },
@@ -22035,11 +22035,11 @@
     "grimoireofgaia:minotaur": [
       {
         "NAME": "the_vault:generic.crit_chance",
-            "MIN": 0.25,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
+        "MIN": 0.25,
+        "MAX": 0.25,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
       },
       {
@@ -22123,20 +22123,20 @@
     "grimoireofgaia:minotaurus": [
       {
         "NAME": "the_vault:generic.crit_chance",
-            "MIN": 0.1,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
+        "MIN": 0.1,
+        "MAX": 0.1,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-            "MIN": 1.5,
-            "MAX": 2.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
+        "MIN": 1.5,
+        "MAX": 2.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
       },
       {

--- a/config/the_vault/vault_mobs.json
+++ b/config/the_vault/vault_mobs.json
@@ -618,7 +618,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -627,7 +627,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -1028,7 +1028,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -1037,7 +1037,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -1492,10 +1492,10 @@
         "NAME": "minecraft:generic.movement_speed",
         "MIN": 0.24,
         "MAX": 0.24,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -3434,7 +3434,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -4266,19 +4266,19 @@
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.2,
-        "MAX": 1.2,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4313,19 +4313,19 @@
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.2,
-        "MAX": 1.2,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4360,19 +4360,19 @@
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.2,
-        "MAX": 1.2,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4407,19 +4407,19 @@
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.2,
-        "MAX": 1.2,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
+            "MIN": 1.2,
+            "MAX": 1.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4940,7 +4940,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -4978,7 +4978,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -5016,7 +5016,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -7188,10 +7188,10 @@
         "NAME": "minecraft:generic.attack_damage",
         "MIN": 1.0,
         "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -8931,7 +8931,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_speed",
@@ -9042,7 +9042,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_speed",
@@ -9153,7 +9153,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_speed",
@@ -9264,7 +9264,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_speed",
@@ -11472,7 +11472,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -11481,7 +11481,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -11931,7 +11931,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -11940,7 +11940,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -18697,9 +18697,9 @@
           {
             "MIN_LEVEL": 0,
             "MIN": 400.0,
-            "MAX": 600.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
+        "MAX": 600.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.06,
             "SCALE_MAX_LEVEL": 49
           },
@@ -18709,7 +18709,7 @@
             "MAX": 540.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
+        "SCALE_PER_LEVEL": 0.1,
             "SCALE_MAX_LEVEL": 79
           },
           {
@@ -18728,7 +18728,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.3,
-            "SCALE_MAX_LEVEL": -1
+        "SCALE_MAX_LEVEL": -1
           }
         ]
       },
@@ -18813,8 +18813,8 @@
             "MIN_LEVEL": 80,
             "MIN": 160.0,
             "MAX": 320.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.2,
             "SCALE_MAX_LEVEL": 89
           },
@@ -18825,7 +18825,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.3,
-            "SCALE_MAX_LEVEL": -1
+        "SCALE_MAX_LEVEL": -1
           }
         ]
       },
@@ -18910,8 +18910,8 @@
             "MIN_LEVEL": 80,
             "MIN": 121.5,
             "MAX": 243.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.2,
             "SCALE_MAX_LEVEL": 89
           },
@@ -18922,7 +18922,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.3,
-            "SCALE_MAX_LEVEL": -1
+        "SCALE_MAX_LEVEL": -1
           }
         ]
       },
@@ -22035,11 +22035,11 @@
     "grimoireofgaia:minotaur": [
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.25,
-        "MAX": 0.25,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
+            "MIN": 0.25,
+            "MAX": 0.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
       },
       {
@@ -22123,20 +22123,20 @@
     "grimoireofgaia:minotaurus": [
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.1,
-        "MAX": 0.1,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
+            "MIN": 0.1,
+            "MAX": 0.1,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.5,
-        "MAX": 2.5,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
+            "MIN": 1.5,
+            "MAX": 2.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
       },
       {

--- a/config/the_vault/vault_mobs.json
+++ b/config/the_vault/vault_mobs.json
@@ -9766,8 +9766,8 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 400.0,
-            "MAX": 600.0,
+            "MIN": 300.0,
+            "MAX": 500.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.06,
@@ -9775,8 +9775,8 @@
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 360.0,
-            "MAX": 540.0,
+            "MIN": 270.0,
+            "MAX": 450.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.1,
@@ -9784,8 +9784,8 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 324.0,
-            "MAX": 486.0,
+            "MIN": 243.0,
+            "MAX": 405.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.2,
@@ -9793,8 +9793,8 @@
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 291.6,
-            "MAX": 437.4,
+            "MIN": 218.7,
+            "MAX": 364.5,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.3,

--- a/config/the_vault/vault_mobs.json
+++ b/config/the_vault/vault_mobs.json
@@ -102,6 +102,15 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 34.0,
+            "MAX": 47.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -274,6 +283,15 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 34.0,
+            "MAX": 47.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -396,6 +414,15 @@
             "MIN_LEVEL": 65,
             "MIN": 23.0,
             "MAX": 32.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 30.0,
+            "MAX": 42.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
@@ -609,7 +636,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -618,7 +645,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "minecraft:enderman": [
@@ -693,7 +720,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -702,7 +729,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -786,7 +813,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -795,7 +822,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -879,7 +906,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 85
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -888,7 +915,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 85
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -972,7 +999,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -981,7 +1008,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -1019,7 +1046,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -1046,6 +1073,15 @@
             "MIN_LEVEL": 65,
             "MIN": 31.0,
             "MAX": 59.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 41.0,
+            "MAX": 78.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
@@ -1135,7 +1171,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -1144,7 +1180,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -1237,7 +1273,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -1246,7 +1282,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -1339,7 +1375,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -1348,7 +1384,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -1436,8 +1472,8 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.6,
-        "MAX": 1.8,
+        "MIN": 2.0,
+        "MAX": 4.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
@@ -1454,35 +1490,12 @@
       },
       {
         "NAME": "minecraft:generic.movement_speed",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.25,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 39
-          },
-          {
-            "MIN_LEVEL": 40,
-            "MIN": 0.28,
-            "MAX": 0.28,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.32,
-            "MAX": 0.32,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 0.24,
+        "MAX": 0.24,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -1677,7 +1690,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -1686,7 +1699,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.057,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -1804,7 +1817,7 @@
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 95.0,
+            "MIN": 82.0,
             "MAX": 108.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
@@ -1929,7 +1942,7 @@
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 95.0,
+            "MIN": 85.0,
             "MAX": 106.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
@@ -2047,15 +2060,6 @@
     ],
     "the_vault:overgrown_tank": [
       {
-        "NAME": "the_vault:generic.reach",
-        "MIN": 1.8,
-        "MAX": 1.8,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
         "MAX": 0.0,
@@ -2075,155 +2079,12 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 5.0,
+        "MIN": 1.5,
+        "MAX": 2.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 3.3000000000000003,
-            "MAX": 5.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 3.5999999999999996,
-            "MAX": 6.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.max_health",
-        "MIN": 60.0,
-        "MAX": 85.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 66.0,
-            "MAX": 93.50000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 72.0,
-            "MAX": 102.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 79.2,
-            "MAX": 112.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 86.39999999999999,
-            "MAX": 122.39999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
-      },
-      {
-        "NAME": "minecraft:generic.knockback_resistance",
-        "MIN": 0.7,
-        "MAX": 1.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "forge:swim_speed",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      }
-    ],
-    "the_vault:blood_tank": [
-      {
-        "NAME": "the_vault:generic.reach",
-        "MIN": 1.8,
-        "MAX": 1.8,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
-        "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": -1
-      },
-      {
-        "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -2262,7 +2123,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 89
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -2271,12 +2132,118 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 201.6,
-            "MAX": 244.79999999999998,
+            "MAX": 244.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
+      },
+      {
+        "NAME": "minecraft:generic.knockback_resistance",
+        "MIN": 1.0,
+        "MAX": 1.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "forge:swim_speed",
+        "MIN": 5.0,
+        "MAX": 5.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      }
+    ],
+    "the_vault:blood_tank": [
+      {
+        "NAME": "the_vault:generic.crit_chance",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.crit_multiplier",
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 0.8,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.attack_damage",
+        "MIN": 1.5,
+        "MAX": 2.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.05,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.max_health",
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 68.0,
+            "MAX": 82.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 34
+          },
+          {
+            "MIN_LEVEL": 35,
+            "MIN": 80.0,
+            "MAX": 100.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 100.0,
+            "MAX": 130.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 64
+          },
+          {
+            "MIN_LEVEL": 65,
+            "MIN": 140.0,
+            "MAX": 170.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 184.8,
+            "MAX": 224.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 201.6,
+            "MAX": 244.8,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
@@ -2368,12 +2335,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 134.0,
+            "MAX": 190.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 125.0,
-            "MAX": 184.0,
+            "MIN": 146.0,
+            "MAX": 207.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
@@ -2487,7 +2463,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -2571,7 +2547,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -2580,7 +2556,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -2664,7 +2640,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -2673,7 +2649,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -2757,7 +2733,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -2766,7 +2742,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -2943,27 +2919,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 33.0,
-            "MAX": 63.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 36.0,
-            "MAX": 69.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -2972,27 +2928,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -3076,45 +3012,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 44.0,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 48.0,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 52.800000000000004,
-            "MAX": 79.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 57.599999999999994,
-            "MAX": 86.39999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -3123,27 +3021,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -3227,27 +3105,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -3256,27 +3114,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -3360,45 +3198,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -3407,27 +3207,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -3511,45 +3291,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -3558,27 +3300,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -3683,6 +3405,15 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 52.8,
+            "MAX": 90.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -3694,7 +3425,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -3744,7 +3475,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -3753,30 +3484,12 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 72.0,
             "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 79.2,
-            "MAX": 99.00000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 86.39999999999999,
-            "MAX": 108.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
@@ -3791,27 +3504,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -3959,7 +3652,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -3968,7 +3661,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "the_vault:t1_drowned": [
@@ -4043,7 +3736,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -4052,7 +3745,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.047,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "the_vault:t2_drowned": [
@@ -4127,7 +3820,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -4136,7 +3829,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "the_vault:t3_drowned": [
@@ -4250,12 +3943,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 165.0,
+            "MAX": 198.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 180.0,
-            "MAX": 200.0,
+            "MAX": 216.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -4375,6 +4077,24 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 44.0,
+            "MAX": 74.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 48.0,
+            "MAX": 81.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -4418,6 +4138,24 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 44.0,
+            "MAX": 75.9,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 48.0,
+            "MAX": 82.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -4429,7 +4167,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -4513,80 +4251,34 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 3.0,
+        "MIN": 0.8,
+        "MAX": 1.2,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4606,80 +4298,34 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 3.0,
+        "MIN": 1.0,
+        "MAX": 1.7,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4699,80 +4345,34 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 2.5,
+        "MIN": 1.4,
+        "MAX": 2.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4796,8 +4396,8 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 3.5,
+        "MIN": 2.2,
+        "MAX": 3.4,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
@@ -4805,67 +4405,21 @@
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.05,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 0.1,
-            "MAX": 0.15,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 0.15,
-            "MAX": 0.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 0.0,
+        "MAX": 0.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.2,
-            "MAX": 1.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          },
-          {
-            "MIN_LEVEL": 50,
-            "MIN": 1.3,
-            "MAX": 1.3,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
-          },
-          {
-            "MIN_LEVEL": 85,
-            "MIN": 1.4,
-            "MAX": 1.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "MIN": 1.2,
+        "MAX": 1.2,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -4949,7 +4503,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -4958,7 +4512,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.057,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -5042,7 +4596,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -5051,7 +4605,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.057,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -5135,7 +4689,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -5144,7 +4698,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -5299,12 +4853,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 176.0,
+            "MAX": 198.00000000000003,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 180.0,
-            "MAX": 200.0,
+            "MIN": 192.0,
+            "MAX": 216.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -5348,7 +4911,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -5357,7 +4920,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -5386,7 +4949,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -5395,7 +4958,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -5424,7 +4987,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -5433,7 +4996,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -5462,7 +5025,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -5471,7 +5034,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -5585,12 +5148,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 27.5,
+            "MAX": 33.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 35.0,
-            "MAX": 40.0,
+            "MIN": 30.0,
+            "MAX": 36.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -5710,12 +5282,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 71.5,
+            "MAX": 82.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 85.0,
-            "MAX": 93.0,
+            "MIN": 78.0,
+            "MAX": 90.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -5835,12 +5416,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 71.5,
+            "MAX": 82.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 85.0,
-            "MAX": 99.0,
+            "MIN": 78.0,
+            "MAX": 90.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -5896,7 +5486,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -5905,30 +5495,12 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 31.2,
             "MAX": 48.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 34.32,
-            "MAX": 52.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 37.44,
-            "MAX": 57.599999999999994,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -5954,7 +5526,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -5963,7 +5535,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -6283,21 +5855,67 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 6.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.6,
+            "MAX": 3.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.6,
+            "MAX": 3.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 180.0,
-        "MAX": 300.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.2,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 400.0,
+            "MAX": 600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 360.0,
+            "MAX": 540.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 320.0,
+            "MAX": 480.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 280.0,
+            "MAX": 420.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -6353,27 +5971,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.5,
-            "MAX": 2.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 3.0,
-            "MAX": 3.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -6394,7 +5992,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -6403,7 +6001,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
@@ -6470,27 +6068,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.5,
-            "MAX": 2.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 3.0,
-            "MAX": 3.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -6511,7 +6089,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -6520,7 +6098,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
@@ -6654,6 +6232,24 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 209.0,
+            "MAX": 275.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 228.0,
+            "MAX": 300.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -6707,26 +6303,72 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 3.0,
-        "MAX": 8.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 3.0,
+            "MAX": 4.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 3.2,
+            "MAX": 4.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 500.0,
-        "MAX": 700.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.18,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 600.0,
+            "MAX": 800.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 540.0,
+            "MAX": 720.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 480.0,
+            "MAX": 640.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 420.0,
+            "MAX": 560.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.9,
-        "MAX": 0.95,
+        "MIN": 1.05,
+        "MAX": 1.1,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -6772,26 +6414,20 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 3.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.2,
-        "SCALE_MAX_LEVEL": -1,
         "LEVELS": [
           {
-            "MIN_LEVEL": 80,
-            "MIN": 4.0,
-            "MAX": 5.0,
+            "MIN_LEVEL": 0,
+            "MIN": 2.0,
+            "MAX": 4.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.2,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
           },
           {
-            "MIN_LEVEL": 90,
-            "MIN": 5.0,
-            "MAX": 6.0,
+            "MIN_LEVEL": 50,
+            "MIN": 2.0,
+            "MAX": 4.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.2,
@@ -6818,7 +6454,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -6827,7 +6463,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
@@ -6889,26 +6525,72 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 5.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 2.5,
+            "MAX": 3.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 2.5,
+            "MAX": 3.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 400.0,
-        "MAX": 650.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.13,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 400.0,
+            "MAX": 600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 360.0,
+            "MAX": 540.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 320.0,
+            "MAX": 480.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 280.0,
+            "MAX": 420.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
-        "MIN": 1.0,
-        "MAX": 1.0,
+        "MIN": 1.1,
+        "MAX": 1.2,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -6927,8 +6609,8 @@
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 0.2,
+        "MAX": 0.2,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -6936,8 +6618,8 @@
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 1.5,
-        "MAX": 1.8,
+        "MIN": 2.5,
+        "MAX": 2.5,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -6945,40 +6627,72 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 8.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.2,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 3.0,
+            "MAX": 5.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 4.0,
+            "MAX": 7.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 80.0,
-            "MAX": 160.0,
+            "MIN": 200.0,
+            "MAX": 400.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_PER_LEVEL": 0.06,
             "SCALE_MAX_LEVEL": 49
           },
           {
-            "MIN_LEVEL": 25,
-            "MIN": 300.0,
-            "MAX": 450.0,
+            "MIN_LEVEL": 50,
+            "MIN": 180.0,
+            "MAX": 360.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 160.0,
+            "MAX": 320.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 140.0,
+            "MAX": 280.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
             "SCALE_MAX_LEVEL": -1
           }
         ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.9,
-        "MAX": 0.95,
+        "MIN": 1.3,
+        "MAX": 1.3,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -7024,21 +6738,67 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.6,
+            "MAX": 3.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.6,
+            "MAX": 3.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 320.0,
-        "MAX": 480.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.16,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 150.0,
+            "MAX": 250.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 135.0,
+            "MAX": 225.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 121.5,
+            "MAX": 202.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 109.35,
+            "MAX": 182.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -7061,6 +6821,15 @@
     ],
     "the_vault:elite_stray": [
       {
+        "NAME": "minecraft:generic.attack_speed",
+        "MIN": 4.0,
+        "MAX": 4.0,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
         "NAME": "minecraft:generic.knockback_resistance",
         "MIN": 0.65,
         "MAX": 1.0,
@@ -7071,8 +6840,8 @@
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 0.2,
+        "MAX": 0.2,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -7081,7 +6850,16 @@
       {
         "NAME": "the_vault:generic.crit_multiplier",
         "MIN": 1.5,
-        "MAX": 1.8,
+        "MAX": 1.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "the_vault:generic.bow_charge_time",
+        "MIN": 0.5,
+        "MAX": 0.5,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -7089,26 +6867,72 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 2.0,
-        "MAX": 5.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.2,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 2.0,
+            "MAX": 4.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 2.5,
+            "MAX": 5.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 400.0,
-        "MAX": 650.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.13,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 175.0,
+            "MAX": 325.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 157.5,
+            "MAX": 292.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 141.75,
+            "MAX": 263.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 127.58,
+            "MAX": 236.93,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.9,
-        "MAX": 0.95,
+        "MIN": 1.3,
+        "MAX": 1.4,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -7166,20 +6990,38 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 80.0,
-            "MAX": 160.0,
+            "MIN": 400.0,
+            "MAX": 600.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_PER_LEVEL": 0.06,
             "SCALE_MAX_LEVEL": 49
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 500.0,
-            "MAX": 700,
+            "MIN": 360.0,
+            "MAX": 540.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.15,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 320.0,
+            "MAX": 480.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 280.0,
+            "MAX": 420.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -7233,26 +7075,72 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 1.0,
-        "MAX": 4.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 0.6,
+            "MAX": 2.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 0.6,
+            "MAX": 2.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 400.0,
-        "MAX": 800.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.15,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 400.0,
+            "MAX": 600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 360.0,
+            "MAX": 540.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 320.0,
+            "MAX": 480.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 280.0,
+            "MAX": 420.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
-        "MIN": 0.7,
-        "MAX": 0.9,
+        "MIN": 1.1,
+        "MAX": 1.1,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -7307,12 +7195,44 @@
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 400.0,
-        "MAX": 800.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 400.0,
+            "MAX": 600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 360.0,
+            "MAX": 540.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 320.0,
+            "MAX": 480.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 280.0,
+            "MAX": 420.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -7363,8 +7283,8 @@
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 15.0,
-        "MAX": 30.0,
+        "MIN": 30.0,
+        "MAX": 40.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
@@ -7483,12 +7403,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 28.6,
+            "MAX": 44.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 32.0,
-            "MAX": 46.0,
+            "MIN": 31.2,
+            "MAX": 48.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -7626,12 +7555,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 126.5,
+            "MAX": 180.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 135.0,
-            "MAX": 194.0,
+            "MIN": 138.0,
+            "MAX": 196.8,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.087,
@@ -7730,7 +7668,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 35
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -7739,7 +7677,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 35
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -7832,7 +7770,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -7841,7 +7779,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -7934,7 +7872,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -7943,7 +7881,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -8181,12 +8119,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 99.0,
+            "MAX": 110.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 105.0,
-            "MAX": 114.0,
+            "MIN": 108.0,
+            "MAX": 120.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.087,
@@ -8324,12 +8271,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.087,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 104.5,
+            "MAX": 119.9,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.087,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 105.0,
-            "MAX": 124.0,
+            "MIN": 114.0,
+            "MAX": 130.8,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.087,
@@ -8458,12 +8414,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 28.6,
+            "MAX": 44.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 32.0,
-            "MAX": 45.0,
+            "MIN": 31.2,
+            "MAX": 48.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -8562,15 +8527,15 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 70
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 30.0,
-            "MAX": 36.0,
+            "MIN": 18.0,
+            "MAX": 26.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
@@ -8578,8 +8543,17 @@
           },
           {
             "MIN_LEVEL": 65,
-            "MIN": 40.0,
-            "MAX": 46.0,
+            "MIN": 32.0,
+            "MAX": 40.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 39.0,
+            "MAX": 48.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
@@ -8587,8 +8561,8 @@
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 46.0,
-            "MAX": 54.0,
+            "MIN": 44.0,
+            "MAX": 52.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.077,
@@ -8691,6 +8665,24 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 9.9,
+            "MAX": 15.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 10.8,
+            "MAX": 16.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -8758,6 +8750,24 @@
             "MIN_LEVEL": 65,
             "MIN": 11.0,
             "MAX": 24.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 12.1,
+            "MAX": 26.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 13.2,
+            "MAX": 28.8,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -8903,7 +8913,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -8912,7 +8922,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -9014,7 +9024,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -9023,7 +9033,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -9125,7 +9135,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.12,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -9134,7 +9144,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -9278,8 +9288,8 @@
     "minecraft:vex": [
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.08,
+        "MIN": 0.5,
+        "MAX": 0.5,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -9435,12 +9445,44 @@
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 225.0,
-        "MAX": 450.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.13,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 350.0,
+            "MAX": 400.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 315.0,
+            "MAX": 360.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 283.5,
+            "MAX": 324.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 255.15,
+            "MAX": 291.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -9454,7 +9496,7 @@
       {
         "NAME": "the_vault:generic.indirect_tp_chance",
         "MIN": 0.25,
-        "MAX": 0.60,
+        "MAX": 0.6,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -9509,12 +9551,44 @@
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 500.0,
-        "MAX": 1000.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.11,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 200.0,
+            "MAX": 300.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 180.0,
+            "MAX": 270.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 162.0,
+            "MAX": 243.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 145.8,
+            "MAX": 218.7,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -9528,7 +9602,7 @@
       {
         "NAME": "the_vault:generic.indirect_tp_chance",
         "MIN": 0.25,
-        "MAX": 0.60,
+        "MAX": 0.6,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -9578,17 +9652,49 @@
         "MAX": 4.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.2,
+        "SCALE_PER_LEVEL": 0.1,
         "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 280.0,
-        "MAX": 470.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.14,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 400.0,
+            "MAX": 450.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 360.0,
+            "MAX": 405.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 324.0,
+            "MAX": 364.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 291.6,
+            "MAX": 328.05,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -9657,12 +9763,44 @@
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 120.0,
-        "MAX": 240.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.13,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 400.0,
+            "MAX": 600.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 360.0,
+            "MAX": 540.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 324.0,
+            "MAX": 486.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 291.6,
+            "MAX": 437.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -9855,8 +9993,8 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 45.0,
-            "MAX": 80.0,
+            "MIN": 35.0,
+            "MAX": 65.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.14,
@@ -9873,8 +10011,17 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 100.0,
-            "MAX": 180.0,
+            "MIN": 55.0,
+            "MAX": 99.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 60.0,
+            "MAX": 108.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.16,
@@ -9970,11 +10117,20 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 50.0,
-            "MAX": 90.0,
+            "MIN": 36.0,
+            "MAX": 61.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 44.0,
+            "MAX": 69.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -10010,19 +10166,19 @@
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 0.1,
+        "MAX": 0.1,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": 20
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 2.0,
+        "MAX": 2.0,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": 20
       },
@@ -10040,8 +10196,8 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 45.0,
-            "MAX": 80.0,
+            "MIN": 35.0,
+            "MAX": 65.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.14,
@@ -10058,8 +10214,17 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 100.0,
-            "MAX": 180.0,
+            "MIN": 55.0,
+            "MAX": 99.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 60.0,
+            "MAX": 108.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.16,
@@ -10155,11 +10320,20 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 50.0,
-            "MAX": 90.0,
+            "MIN": 36.0,
+            "MAX": 61.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 44.0,
+            "MAX": 69.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -10195,19 +10369,19 @@
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 0.1,
+        "MAX": 0.1,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": 20
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 2.0,
+        "MAX": 2.0,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": 20
       },
@@ -10225,8 +10399,8 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 45.0,
-            "MAX": 80.0,
+            "MIN": 35.0,
+            "MAX": 65.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.14,
@@ -10243,8 +10417,17 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 100.0,
-            "MAX": 180.0,
+            "MIN": 55.0,
+            "MAX": 99.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 60.0,
+            "MAX": 108.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.16,
@@ -10340,11 +10523,20 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 50.0,
-            "MAX": 90.0,
+            "MIN": 36.0,
+            "MAX": 61.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 44.0,
+            "MAX": 69.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -10380,19 +10572,19 @@
       },
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 0.1,
+        "MAX": 0.1,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": 20
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 2.0,
+        "MAX": 2.0,
         "OPERATOR": "set",
-        "ROLL_CHANCE": 0.8,
+        "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": 20
       },
@@ -10410,8 +10602,8 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 45.0,
-            "MAX": 80.0,
+            "MIN": 35.0,
+            "MAX": 65.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.14,
@@ -10428,8 +10620,17 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 100.0,
-            "MAX": 180.0,
+            "MIN": 55.0,
+            "MAX": 99.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 60.0,
+            "MAX": 108.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.16,
@@ -10525,11 +10726,20 @@
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 50.0,
-            "MAX": 90.0,
+            "MIN": 36.0,
+            "MAX": 61.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.16,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": -1
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 44.0,
+            "MAX": 69.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -10636,27 +10846,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.32,
-            "MAX": 1.7600000000000002,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.44,
-            "MAX": 1.92,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -10686,39 +10876,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 47.300000000000004,
+            "MIN": 47.3,
             "MAX": 66.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 51.6,
             "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 56.760000000000005,
-            "MAX": 79.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 61.92,
-            "MAX": 86.39999999999999,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -10808,7 +10980,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 75
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -10817,7 +10989,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 75
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -10888,8 +11060,8 @@
     "the_vault:levishroom": [
       {
         "NAME": "the_vault:generic.crit_chance",
-        "MIN": 0.3,
-        "MAX": 0.3,
+        "MIN": 0.1,
+        "MAX": 0.1,
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
@@ -10906,8 +11078,8 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 0.5,
-        "MAX": 0.7,
+        "MIN": 1.0,
+        "MAX": 2.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
@@ -10918,8 +11090,8 @@
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 20.0,
-            "MAX": 30.0,
+            "MIN": 10.0,
+            "MAX": 18.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -10927,8 +11099,8 @@
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 33.0,
-            "MAX": 44.0,
+            "MIN": 24.0,
+            "MAX": 32.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -10936,17 +11108,26 @@
           },
           {
             "MIN_LEVEL": 65,
-            "MIN": 50.0,
-            "MAX": 65.0,
+            "MIN": 30.0,
+            "MAX": 46.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 84
+            "SCALE_MAX_LEVEL": 79
           },
           {
-            "MIN_LEVEL": 85,
-            "MIN": 65.0,
-            "MAX": 85.0,
+            "MIN_LEVEL": 80,
+            "MIN": 33.0,
+            "MAX": 50.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 36.0,
+            "MAX": 55.2,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -10957,7 +11138,7 @@
       {
         "NAME": "minecraft:generic.movement_speed",
         "MIN": 1.0,
-        "MAX": 1.0,
+        "MAX": 1.2,
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -11072,6 +11253,24 @@
             "MIN_LEVEL": 65,
             "MIN": 32.0,
             "MAX": 46.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 35.2,
+            "MAX": 50.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 38.4,
+            "MAX": 55.2,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -11291,7 +11490,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -11300,7 +11499,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -11393,7 +11592,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 60
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -11402,7 +11601,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 60
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -11618,12 +11817,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 24.2,
+            "MAX": 35.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 26.0,
-            "MAX": 36.0,
+            "MIN": 26.4,
+            "MAX": 38.4,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -11676,7 +11884,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 60
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -11685,7 +11893,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.07,
-        "SCALE_MAX_LEVEL": 60
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -11705,7 +11913,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.055,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -11714,7 +11922,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -11748,7 +11956,7 @@
       {
         "NAME": "the_vault:generic.crit_chance",
         "MIN": 0.0,
-        "MAX": 0.0,
+        "MAX": 0.2,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -11756,8 +11964,8 @@
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "MIN": 0.0,
-        "MAX": 0.0,
+        "MIN": 1.2,
+        "MAX": 1.6,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
@@ -11829,12 +12037,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 33.0,
+            "MAX": 39.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 28.0,
-            "MAX": 35.0,
+            "MIN": 36.0,
+            "MAX": 42.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.1,
@@ -11954,15 +12171,24 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 83.6,
+            "MAX": 97.9,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 91.0,
-            "MAX": 108.0,
+            "MIN": 91.2,
+            "MAX": 106.8,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.089,
+            "SCALE_PER_LEVEL": 0.08,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -12079,12 +12305,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 72.6,
+            "MAX": 83.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 85.0,
-            "MAX": 97.0,
+            "MIN": 79.2,
+            "MAX": 91.2,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.1,
@@ -12213,6 +12448,24 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.11,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 26.4,
+            "MAX": 40.7,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.11,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 28.8,
+            "MAX": 44.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.11,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -12224,7 +12477,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": 40
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -12306,7 +12559,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": 84
+            "SCALE_MAX_LEVEL": 64
           },
           {
             "MIN_LEVEL": 65,
@@ -12347,7 +12600,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 84
+            "SCALE_MAX_LEVEL": 64
           },
           {
             "MIN_LEVEL": 65,
@@ -12408,27 +12661,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.54,
-            "MAX": 2.09,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.68,
-            "MAX": 2.28,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -12458,7 +12691,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.11,
-            "SCALE_MAX_LEVEL": 89
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -12467,7 +12700,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.11,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
@@ -12601,12 +12834,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.11,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 27.0,
+            "MAX": 38.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.11,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 28.0,
-            "MAX": 38.0,
+            "MIN": 35.0,
+            "MAX": 42.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.11,
@@ -12735,15 +12977,24 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 86.9,
+            "MAX": 103.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 104.0,
-            "MAX": 119.0,
+            "MIN": 94.8,
+            "MAX": 112.8,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.089,
+            "SCALE_PER_LEVEL": 0.08,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -12839,7 +13090,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -12848,7 +13099,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.057,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -12932,7 +13183,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -12941,7 +13192,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13025,7 +13276,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13034,7 +13285,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13118,7 +13369,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13127,7 +13378,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13211,7 +13462,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13220,7 +13471,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13304,7 +13555,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.018,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13313,7 +13564,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13397,7 +13648,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13406,7 +13657,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.057,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13490,7 +13741,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13499,7 +13750,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13583,7 +13834,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13592,7 +13843,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13676,7 +13927,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13685,7 +13936,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13769,7 +14020,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13778,7 +14029,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13862,7 +14113,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.018,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13871,7 +14122,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -13955,27 +14206,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -13984,45 +14215,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 26.400000000000002,
-            "MAX": 31.900000000000002,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 28.799999999999997,
-            "MAX": 34.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 31.68,
-            "MAX": 38.28,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 34.559999999999995,
-            "MAX": 41.76,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -14115,27 +14308,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -14144,45 +14317,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 41.800000000000004,
-            "MAX": 55.00000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 45.6,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 50.160000000000004,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 54.72,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -14275,27 +14410,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 90,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -14304,45 +14419,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 55.00000000000001,
-            "MAX": 71.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 60.0,
-            "MAX": 78.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 66.0,
-            "MAX": 85.80000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 72.0,
-            "MAX": 93.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -14435,27 +14512,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -14464,45 +14521,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 77.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 84.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 92.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 100.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -14595,27 +14614,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.018,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.018,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.018,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -14624,45 +14623,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 77.0,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 84.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 92.4,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 100.8,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -14755,7 +14716,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.087,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -14764,7 +14725,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.057,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -14848,7 +14809,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -14857,7 +14818,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -14941,7 +14902,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -14950,7 +14911,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -15034,7 +14995,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -15043,7 +15004,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -15127,7 +15088,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -15136,7 +15097,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -15220,7 +15181,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.018,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -15229,7 +15190,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -15244,12 +15205,12 @@
     "the_vault:skeleton_pirate_t0": [
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 8.0,
-        "MAX": 16.0,
+        "MIN": 4.0,
+        "MAX": 8.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -15258,7 +15219,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -15323,6 +15284,15 @@
             "SCALE_MAX_LEVEL": -1
           }
         ]
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.1,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -15337,12 +15307,12 @@
     "the_vault:skeleton_pirate_t1": [
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 32.0,
-        "MAX": 48.0,
+        "MIN": 16.0,
+        "MAX": 24.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -15351,7 +15321,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -15422,6 +15392,15 @@
         "MIN": 5.0,
         "MAX": 5.0,
         "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
@@ -15430,12 +15409,12 @@
     "the_vault:skeleton_pirate_t2": [
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 40.0,
-        "MAX": 58.0,
+        "MIN": 30.0,
+        "MAX": 50.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -15444,7 +15423,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -15518,13 +15497,22 @@
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "the_vault:skeleton_pirate_t3": [
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 50.0,
-        "MAX": 70.0,
+        "MIN": 40.0,
+        "MAX": 60.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
@@ -15608,6 +15596,15 @@
         "MIN": 5.0,
         "MAX": 5.0,
         "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
@@ -15704,6 +15701,15 @@
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "the_vault:skeleton_pirate_t5": [
@@ -15797,6 +15803,15 @@
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
         "SCALE_MAX_LEVEL": -1
+      },
+      {
+        "NAME": "minecraft:generic.movement_speed",
+        "MIN": 1.05,
+        "MAX": 1.15,
+        "OPERATOR": "multiply",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "the_vault:mushroom_t0": [
@@ -15871,7 +15886,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.087,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -15880,7 +15895,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.057,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -15964,7 +15979,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -15973,7 +15988,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -16057,7 +16072,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -16066,7 +16081,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -16150,7 +16165,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -16159,7 +16174,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -16243,7 +16258,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -16252,7 +16267,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -16336,7 +16351,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.018,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -16345,7 +16360,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -16422,12 +16437,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 149.6,
+            "MAX": 180.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 156.0,
-            "MAX": 178.0,
+            "MIN": 163.2,
+            "MAX": 196.8,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -16480,7 +16504,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -16489,7 +16513,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -16526,17 +16550,49 @@
         "MAX": 6.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.08,
+        "SCALE_PER_LEVEL": 0.1,
         "SCALE_MAX_LEVEL": 20
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 400.0,
-        "MAX": 600.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.13,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 175.0,
+            "MAX": 325.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 157.5,
+            "MAX": 292.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 141.75,
+            "MAX": 263.25,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 127.58,
+            "MAX": 236.93,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "forge:swim_speed",
@@ -16620,7 +16676,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -16629,7 +16685,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.knockback_resistance",
@@ -16722,7 +16778,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -16731,7 +16787,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.knockback_resistance",
@@ -16824,7 +16880,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -16833,7 +16889,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.knockback_resistance",
@@ -16874,12 +16930,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 58.3,
+            "MAX": 70.4,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 59.0,
-            "MAX": 69.0,
+            "MIN": 63.6,
+            "MAX": 76.8,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -16894,7 +16959,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -16999,6 +17064,24 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 45.1,
+            "MAX": 63.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 49.2,
+            "MAX": 69.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.05,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -17010,7 +17093,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 90
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -17188,12 +17271,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 37.4,
+            "MAX": 52.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 38.0,
-            "MAX": 54.0,
+            "MIN": 40.8,
+            "MAX": 57.6,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
@@ -17313,12 +17405,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 33.0,
+            "MAX": 41.8,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 38.0,
-            "MAX": 56.0,
+            "MIN": 36.0,
+            "MAX": 45.6,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
@@ -17447,12 +17548,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 45.1,
+            "MAX": 57.2,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 45.0,
-            "MAX": 54.0,
+            "MIN": 49.2,
+            "MAX": 62.4,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
@@ -17572,12 +17682,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 13.2,
+            "MAX": 17.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 15.0,
-            "MAX": 21.0,
+            "MIN": 14.4,
+            "MAX": 19.2,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
@@ -17660,12 +17779,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 154.0,
+            "MAX": 209.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.08,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 160.0,
-            "MAX": 210.0,
+            "MIN": 168.0,
+            "MAX": 228.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.08,
@@ -17739,12 +17867,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 28.6,
+            "MAX": 44.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.09,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 32.0,
-            "MAX": 46.0,
+            "MIN": 31.2,
+            "MAX": 48.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -17779,7 +17916,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -17788,7 +17925,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -17881,7 +18018,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -17890,7 +18027,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -17983,7 +18120,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -17992,7 +18129,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -18485,12 +18622,21 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 13.2,
+            "MAX": 17.6,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.067,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 15.0,
-            "MAX": 21.0,
+            "MIN": 14.4,
+            "MAX": 19.2,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.067,
@@ -18543,27 +18689,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.1,
-            "MAX": 4.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.2,
-            "MAX": 5.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -18574,34 +18700,34 @@
             "MAX": 600.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_PER_LEVEL": 0.06,
             "SCALE_MAX_LEVEL": 49
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 800.0,
-            "MAX": 1200.0,
+            "MIN": 360.0,
+            "MAX": 540.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 1400.0,
-            "MAX": 2000.0,
+            "MIN": 320.0,
+            "MAX": 480.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 2400.0,
-            "MAX": 3000.0,
+            "MIN": 280.0,
+            "MAX": 420.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_PER_LEVEL": 0.3,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -18660,27 +18786,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.1,
-            "MAX": 4.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.2,
-            "MAX": 5.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -18691,34 +18797,34 @@
             "MAX": 400.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_PER_LEVEL": 0.06,
             "SCALE_MAX_LEVEL": 49
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 600.0,
-            "MAX": 800.0,
+            "MIN": 180.0,
+            "MAX": 360.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 1000.0,
-            "MAX": 1400.0,
+            "MIN": 160.0,
+            "MAX": 320.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 1400.0,
-            "MAX": 2200.0,
+            "MIN": 140.0,
+            "MAX": 280.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_PER_LEVEL": 0.3,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -18773,31 +18879,11 @@
       {
         "NAME": "minecraft:generic.attack_damage",
         "MIN": 1.5,
-        "MAX": 3.5,
+        "MAX": 4.0,
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.6,
-            "MAX": 4.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.8,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.1,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -18808,34 +18894,34 @@
             "MAX": 300.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
+            "SCALE_PER_LEVEL": 0.06,
             "SCALE_MAX_LEVEL": 49
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 400.0,
-            "MAX": 600.0,
+            "MIN": 135.0,
+            "MAX": 270.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
-            "MIN": 800.0,
-            "MAX": 1000.0,
+            "MIN": 121.5,
+            "MAX": 243.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 1000.0,
-            "MAX": 1600.0,
+            "MIN": 109.35,
+            "MAX": 218.7,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.077,
+            "SCALE_PER_LEVEL": 0.3,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -18898,12 +18984,44 @@
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "MIN": 800.0,
-        "MAX": 1200.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.14,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 450.0,
+            "MAX": 500.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.06,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 405.0,
+            "MAX": 450.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
+          },
+          {
+            "MIN_LEVEL": 80,
+            "MIN": 364.5,
+            "MAX": 405.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": 89
+          },
+          {
+            "MIN_LEVEL": 90,
+            "MIN": 328.05,
+            "MAX": 364.5,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.3,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.movement_speed",
@@ -19005,27 +19123,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.08,
-        "SCALE_MAX_LEVEL": 75,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -19034,45 +19132,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 75,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 45.1,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 49.199999999999996,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 54.12,
-            "MAX": 79.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 59.03999999999999,
-            "MAX": 86.39999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -19107,7 +19167,7 @@
             "SCALE_MAX_LEVEL": 64
           },
           {
-            "MIN_LEVEL": 50,
+            "MIN_LEVEL": 65,
             "MIN": 75.0,
             "MAX": 75.0,
             "OPERATOR": "set",
@@ -19324,7 +19384,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -19348,7 +19408,7 @@
             "SCALE_MAX_LEVEL": 64
           },
           {
-            "MIN_LEVEL": 50,
+            "MIN_LEVEL": 65,
             "MIN": 90.0,
             "MAX": 100.0,
             "OPERATOR": "set",
@@ -19449,7 +19509,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -19473,7 +19533,7 @@
             "SCALE_MAX_LEVEL": 64
           },
           {
-            "MIN_LEVEL": 50,
+            "MIN_LEVEL": 65,
             "MIN": 80.0,
             "MAX": 100.0,
             "OPERATOR": "set",
@@ -19574,7 +19634,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -19598,7 +19658,7 @@
             "SCALE_MAX_LEVEL": 64
           },
           {
-            "MIN_LEVEL": 50,
+            "MIN_LEVEL": 65,
             "MIN": 150.0,
             "MAX": 150.0,
             "OPERATOR": "set",
@@ -19830,7 +19890,7 @@
             "SCALE_MAX_LEVEL": 64
           },
           {
-            "MIN_LEVEL": 50,
+            "MIN_LEVEL": 65,
             "MIN": 75.0,
             "MAX": 100.0,
             "OPERATOR": "set",
@@ -19931,7 +19991,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -19955,7 +20015,7 @@
             "SCALE_MAX_LEVEL": 64
           },
           {
-            "MIN_LEVEL": 50,
+            "MIN_LEVEL": 65,
             "MIN": 100.0,
             "MAX": 110.0,
             "OPERATOR": "set",
@@ -20071,7 +20131,7 @@
             "SCALE_MAX_LEVEL": 64
           },
           {
-            "MIN_LEVEL": 50,
+            "MIN_LEVEL": 65,
             "MIN": 125.0,
             "MAX": 125.0,
             "OPERATOR": "set",
@@ -20172,7 +20232,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 20
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -20196,7 +20256,7 @@
             "SCALE_MAX_LEVEL": 64
           },
           {
-            "MIN_LEVEL": 50,
+            "MIN_LEVEL": 65,
             "MIN": 50.0,
             "MAX": 60.0,
             "OPERATOR": "set",
@@ -21623,59 +21683,64 @@
       },
       {
         "NAME": "minecraft:generic.attack_damage",
-        "MIN": 4.0,
-        "MAX": 7.0,
-        "OPERATOR": "set",
-        "ROLL_CHANCE": 1.0,
-        "SCALE_PER_LEVEL": 0.1,
-        "SCALE_MAX_LEVEL": -1
+        "LEVELS": [
+          {
+            "MIN_LEVEL": 0,
+            "MIN": 3.0,
+            "MAX": 5.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 49
+          },
+          {
+            "MIN_LEVEL": 50,
+            "MIN": 4.0,
+            "MAX": 7.0,
+            "OPERATOR": "set",
+            "ROLL_CHANCE": 1.0,
+            "SCALE_PER_LEVEL": 0.2,
+            "SCALE_MAX_LEVEL": -1
+          }
+        ]
       },
       {
         "NAME": "minecraft:generic.max_health",
         "LEVELS": [
           {
             "MIN_LEVEL": 0,
-            "MIN": 60.0,
-            "MAX": 80.0,
+            "MIN": 175.0,
+            "MAX": 325.0,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 34
-          },
-          {
-            "MIN_LEVEL": 35,
-            "MIN": 100.0,
-            "MAX": 120.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_PER_LEVEL": 0.06,
             "SCALE_MAX_LEVEL": 49
           },
           {
             "MIN_LEVEL": 50,
-            "MIN": 130.0,
-            "MAX": 160.0,
+            "MIN": 157.5,
+            "MAX": 292.5,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
-            "SCALE_MAX_LEVEL": 64
+            "SCALE_PER_LEVEL": 0.1,
+            "SCALE_MAX_LEVEL": 79
           },
           {
-            "MIN_LEVEL": 65,
-            "MIN": 200.0,
-            "MAX": 220.0,
+            "MIN_LEVEL": 80,
+            "MIN": 141.75,
+            "MAX": 263.25,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_PER_LEVEL": 0.2,
             "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
-            "MIN": 240.0,
-            "MAX": 300.0,
+            "MIN": 127.58,
+            "MAX": 236.93,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.08,
+            "SCALE_PER_LEVEL": 0.3,
             "SCALE_MAX_LEVEL": -1
           }
         ]
@@ -21970,17 +22035,12 @@
     "grimoireofgaia:minotaur": [
       {
         "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.25,
-            "MAX": 0.25,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          }
-        ]
+        "MIN": 0.25,
+        "MAX": 0.25,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -22063,31 +22123,21 @@
     "grimoireofgaia:minotaurus": [
       {
         "NAME": "the_vault:generic.crit_chance",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 0.1,
-            "MAX": 0.1,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          }
-        ]
+        "MIN": 0.1,
+        "MAX": 0.1,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 1.5,
-            "MAX": 2.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.0,
-            "SCALE_MAX_LEVEL": 49
-          }
-        ]
+        "MIN": 1.5,
+        "MAX": 2.5,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.0,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -22656,7 +22706,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -22665,7 +22715,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -22674,7 +22724,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "thermal:blitz": [
@@ -22717,7 +22767,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -22726,7 +22776,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -22735,7 +22785,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "thermal:basalz": [
@@ -22778,7 +22828,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -22787,7 +22837,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -22796,7 +22846,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "alexsmobs:guster": [
@@ -22839,7 +22889,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -22848,7 +22898,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_multiplier",
@@ -22857,7 +22907,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 0.8,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 50
+        "SCALE_MAX_LEVEL": -1
       }
     ],
     "alexsmobs:orca": [
@@ -23305,7 +23355,7 @@
         "OPERATOR": "multiply",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.0,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -23314,7 +23364,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -23323,7 +23373,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 80
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -23411,17 +23461,12 @@
       },
       {
         "NAME": "minecraft:generic.max_health",
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 0,
-            "MIN": 70.0,
-            "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 49
-          }
-        ]
+        "MIN": 70.0,
+        "MAX": 75.0,
+        "OPERATOR": "set",
+        "ROLL_CHANCE": 1.0,
+        "SCALE_PER_LEVEL": 0.09,
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -23630,27 +23675,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -23659,45 +23684,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 26.400000000000002,
-            "MAX": 31.900000000000002,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 28.799999999999997,
-            "MAX": 34.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 31.68,
-            "MAX": 38.28,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 34.559999999999995,
-            "MAX": 41.76,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -23781,27 +23768,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.01,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.01,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -23810,45 +23777,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 41.800000000000004,
-            "MAX": 55.00000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 45.6,
-            "MAX": 60.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 50.160000000000004,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 54.72,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -23932,27 +23861,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 90,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -23961,45 +23870,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 90,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 55.00000000000001,
-            "MAX": 71.5,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 60.0,
-            "MAX": 78.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 66.0,
-            "MAX": 85.80000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 72.0,
-            "MAX": 93.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -24083,27 +23954,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.015,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.015,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -24112,45 +23963,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 77.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 84.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 92.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 100.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",
@@ -24170,27 +23983,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 33.0,
-            "MAX": 63.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 36.0,
-            "MAX": 69.6,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -24199,27 +23992,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.05,
-        "SCALE_MAX_LEVEL": 50,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.05,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -24303,45 +24076,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 44.0,
-            "MAX": 66.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 48.0,
-            "MAX": 72.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 52.800000000000004,
-            "MAX": 79.2,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 57.599999999999994,
-            "MAX": 86.39999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -24350,27 +24085,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": 80,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 1.1,
-            "MAX": 3.3000000000000003,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 1.2,
-            "MAX": 3.5999999999999996,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -24454,27 +24169,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -24483,27 +24178,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -24587,45 +24262,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -24634,27 +24271,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -24738,45 +24355,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 60.50000000000001,
-            "MAX": 88.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 66.0,
-            "MAX": 96.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 72.60000000000001,
-            "MAX": 105.60000000000001,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 79.2,
-            "MAX": 115.19999999999999,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.067,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.attack_damage",
@@ -24785,27 +24364,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.03,
-        "SCALE_MAX_LEVEL": -1,
-        "LEVELS": [
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 2.2,
-            "MAX": 4.4,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 2.4,
-            "MAX": 4.8,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.03,
-            "SCALE_MAX_LEVEL": -1
-          }
-        ]
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "the_vault:generic.crit_chance",
@@ -24919,7 +24478,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -24928,30 +24487,12 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 31.2,
             "MAX": 48.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 34.32,
-            "MAX": 52.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 37.44,
-            "MAX": 57.599999999999994,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -25007,7 +24548,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -25016,30 +24557,12 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 61.2,
             "MAX": 75.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 76.32,
-            "MAX": 82.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 83.44,
-            "MAX": 90.599999999999994,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -25095,7 +24618,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -25104,30 +24627,12 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 68.2,
             "MAX": 80.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 81.32,
-            "MAX": 95.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 96.44,
-            "MAX": 110.599999999999994,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -25183,7 +24688,7 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": 89
+            "SCALE_MAX_LEVEL": 79
           },
           {
             "MIN_LEVEL": 80,
@@ -25192,30 +24697,12 @@
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
+            "SCALE_MAX_LEVEL": 89
           },
           {
             "MIN_LEVEL": 90,
             "MIN": 81.2,
             "MAX": 90.0,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 80,
-            "MIN": 91.32,
-            "MAX": 100.800000000000004,
-            "OPERATOR": "set",
-            "ROLL_CHANCE": 1.0,
-            "SCALE_PER_LEVEL": 0.09,
-            "SCALE_MAX_LEVEL": -1
-          },
-          {
-            "MIN_LEVEL": 90,
-            "MIN": 101.44,
-            "MAX": 130.599999999999994,
             "OPERATOR": "set",
             "ROLL_CHANCE": 1.0,
             "SCALE_PER_LEVEL": 0.09,
@@ -25500,7 +24987,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.018,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "minecraft:generic.max_health",
@@ -25509,7 +24996,7 @@
         "OPERATOR": "set",
         "ROLL_CHANCE": 1.0,
         "SCALE_PER_LEVEL": 0.067,
-        "SCALE_MAX_LEVEL": 100
+        "SCALE_MAX_LEVEL": -1
       },
       {
         "NAME": "forge:swim_speed",


### PR DESCRIPTION
* Vault Mobs: Align stats with recent Vanilla VH changes, accounting for WV-specific mechanics.
* Scaling Fix: Resolved an issue where some mobs stopped scaling past certain levels.
* POI/Trash Mobs: Removed redundant level overrides.
* Guardian Mobs:
  * Significant HP reduction at lower levels.
  * Minor HP reduction at higher levels.
* Elite/Boss Mobs (VH Parity Adjustments):
  * Smoothed out HP scaling, removing disproportionate spikes at certain levels.
  * Reduced power at lower levels (addressing Vanilla VH's pre-50 difficulty).
  * Slightly lowered max HP to:
    * Improve balance in the Lab room.
    * Prevent excessive difficulty for Brutal Bosses objectives (Vanilla HP values were overtuned).