### PR TITLE
fix: josh's themes not appearing in lvl50+ vaults

### DIFF
--- a/config/the_vault/vault_crystal.json
+++ b/config/the_vault/vault_crystal.json
@@ -462,6 +462,18 @@
         "level": 50,
         "pool": [
           {
+            "value": "the_vault:skaia_vault_autumn_cherry_grove",
+            "weight": 20
+          },
+          {
+            "value": "the_vault:skaia_vault_prismatic_umbra",
+            "weight": 20
+          },
+          {
+            "value": "the_vault:skaia_vault_prismatic_lumen",
+            "weight": 20
+          },
+          {
             "value": "the_vault:classic_vault_dark_cavern",
             "weight": 9
           },


### PR DESCRIPTION
did not realize there was a new 50+ group so I never added them here