### PR TITLE
refreshed pack metas

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -394,7 +394,7 @@ hash = "22c7b00429cc9c26be4b66824dc0b929803d3100eaec8b25d38ca53a08423347"
 
 [[files]]
 file = "config/the_vault/card/decks.json"
-hash = "bda19cf972b42962385ce0fac828790a2d98e266d47b73c37281bf50c1d1dfa7"
+hash = "4dcac453181e6aa27b147ed7c4b93ec6fbf0278043d716d858f446b55312ffa2"
 
 [[files]]
 file = "config/the_vault/card/modifiers.json"
@@ -414,7 +414,7 @@ hash = "aff7b81d79152800045cbfe2bb7bbd651df647d57a34ed942d1a7f744f7391e6"
 
 [[files]]
 file = "config/the_vault/card_shop_pedestal.json"
-hash = "6a5f6a47be19b77f90fbba352cda05c2cd97c3550b349e93cbfe937daa20e635"
+hash = "ef7aae9da907739baf320624d2de76065a669f2b8e94f7bb52ceb9050c58fa30"
 
 [[files]]
 file = "config/the_vault/catalyst.json"
@@ -978,7 +978,7 @@ hash = "6cf48a9518da3716cddce16105af2b1ca421a58d64eea72cd1d068138ae65c1b"
 
 [[files]]
 file = "config/the_vault/gen/1.0/loot_tables/base_crate_cursed_100.json"
-hash = "e4c645cb1053e5da0f054f4172a365e8c39484981aa89c06c54f17f82c0b8141"
+hash = "f22bcdb4ead54e765365d9fe7c64f8af2ac9d7d006183e648ad4aba9d18eba39"
 
 [[files]]
 file = "config/the_vault/gen/1.0/loot_tables/base_crate_cursed_20.json"
@@ -986,23 +986,23 @@ hash = "ecbccebd11e6448aaeaaff30e5556ab67f145a7e16282e76db872444730f3545"
 
 [[files]]
 file = "config/the_vault/gen/1.0/loot_tables/base_crate_cursed_2_100.json"
-hash = "5e3d4c898c101b5987796740b936659233e14e9fac5a9d04326324e6f123dee3"
+hash = "ebd711d05c20ee0694df8c2a45c19b3b032c572a0936838d65d1fd411a8d32b0"
 
 [[files]]
 file = "config/the_vault/gen/1.0/loot_tables/base_crate_cursed_2_50.json"
-hash = "765a9285581b5711f3e81b40f74f4b80e97e16896488c1e9c280f527c195afc4"
+hash = "49539212d0a3adb884fad99eff6810b391f7520c71609644642f1e10585a2076"
 
 [[files]]
 file = "config/the_vault/gen/1.0/loot_tables/base_crate_cursed_3_100.json"
-hash = "38cd552686e83e54750a81441fd2be626585b7394a3c645c81f4bf0f7a344716"
+hash = "e4316e16560bba0bd420b093e338f504a3f9bee7edf8a10a69f69202cde24813"
 
 [[files]]
 file = "config/the_vault/gen/1.0/loot_tables/base_crate_cursed_3_50.json"
-hash = "b670f639d3cc8bd33f502d98ba6636c2b247bce23cfd0975f39938148fd82bde"
+hash = "3f437f88dde433b15ac56d89949c2b004cf877075953fe9a49fa531d357d01fe"
 
 [[files]]
 file = "config/the_vault/gen/1.0/loot_tables/base_crate_cursed_50.json"
-hash = "ea73782dedce5bd51bed0362d4c8f0f2c70c3a608bacf8ce59ff2b047b53ed94"
+hash = "a8a73f08c91842437d5951d38d802d7f43518a2742f4bd25ffe39f0955e2332c"
 
 [[files]]
 file = "config/the_vault/gen/1.0/loot_tables/base_crate_template.json"
@@ -14534,7 +14534,7 @@ hash = "8fe2b15fa3ec3c71a9467a4587c3a6eb658d2b680e49f197605a2a18ac0ae1e8"
 
 [[files]]
 file = "config/the_vault/raid_actions.json"
-hash = "affc76c517ebfcbcaca7322bc00607e2c6a23c80db974bef0afeca2aaca3558f"
+hash = "975ba061aa04e71c6bd0c759aab0d361e765e7d079d6e5c698e209d58c034d64"
 
 [[files]]
 file = "config/the_vault/rare_shop_pedestal.json"
@@ -21766,6 +21766,11 @@ hash = "cb52803e329f4eeeccece6760533e5e665a6ae934499f8e81b641d8e62dd695b"
 metafile = true
 
 [[files]]
+file = "mods/hide-broken-blocks-scannable-addon.pw.toml"
+hash = "003947b7d749c3c7bac5dda6415eb2af9b38c9aa652b3c2e5786ea956ecc8a80"
+metafile = true
+
+[[files]]
 file = "mods/hostile-neural-networks.pw.toml"
 hash = "5f2ba207e0c070c044c7b5c2dc9d31508da3f847cecfe87d0ce7b905fad4d4c4"
 metafile = true
@@ -22942,7 +22947,7 @@ metafile = true
 
 [[files]]
 file = "mods/vhat-can-i-roll-vault-hunters-3-addon.pw.toml"
-hash = "7bded01297e122af0d4a3fc485e93c19929b28a1967379f26fa94e11388d2f08"
+hash = "fd337f5363335578da3ba0412794deca3f1d89af3599a60506da6dc5830577d4"
 metafile = true
 
 [[files]]

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "9d8a9a705097830139b3a189dac137fb31698ef341d26b5a2061f59225276395"
+hash = "4aa5af13d5c879f4243f73fa724537d663b10aed5dbf2465deecb7db20a34f7c"
 
 [versions]
 forge = "40.2.21"


### PR DESCRIPTION
previous merge introduced incorrect hash for `VHat Can I Roll? - Vault Hunters 3 addon`, required a `packwiz refresh`.