### PR TITLE
Add items to greed shops

### DIFF
--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -348,6 +348,7 @@
                             "modifiers": [
                                 "the_vault:wooden_cascade",
                                 "the_vault:wooden_cascade",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
@@ -373,6 +374,8 @@
                             "modifiers": [
                                 "the_vault:wooden_cascade",
                                 "the_vault:wooden_cascade",
+                                "@the_vault:companion_modifiers",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
@@ -398,6 +401,8 @@
                             "modifiers": [
                                 "the_vault:wooden_cascade",
                                 "the_vault:wooden_cascade",
+                                "the_vault:wooden_cascade",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
@@ -423,6 +428,9 @@
                             "modifiers": [
                                 "the_vault:wooden_cascade",
                                 "the_vault:wooden_cascade",
+                                "the_vault:wooden_cascade",
+                                "@the_vault:companion_modifiers",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -217,6 +217,7 @@
                                 "the_vault:coin_cascade",
                                 "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
                             "model": {
@@ -243,6 +244,8 @@
                                 "the_vault:coin_cascade",
                                 "@the_vault:companion_modifiers",
                                 "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
@@ -271,6 +274,8 @@
                                 "the_vault:coin_cascade",
                                 "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
                             "model": {
@@ -298,6 +303,9 @@
                                 "the_vault:coin_cascade",
                                 "@the_vault:companion_modifiers",
                                 "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
@@ -350,6 +358,7 @@
                                 "the_vault:wooden_cascade",
                                 "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
                             "model": {
@@ -376,6 +385,8 @@
                                 "the_vault:wooden_cascade",
                                 "@the_vault:companion_modifiers",
                                 "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
@@ -404,6 +415,8 @@
                                 "the_vault:wooden_cascade",
                                 "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
                             "model": {
@@ -431,6 +444,9 @@
                                 "the_vault:wooden_cascade",
                                 "@the_vault:companion_modifiers",
                                 "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
@@ -483,6 +499,7 @@
                                 "the_vault:ornate_cascade",
                                 "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
                             "model": {
@@ -509,6 +526,8 @@
                                 "the_vault:ornate_cascade",
                                 "@the_vault:companion_modifiers",
                                 "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
@@ -537,6 +556,8 @@
                                 "the_vault:ornate_cascade",
                                 "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],
                             "model": {
@@ -564,6 +585,9 @@
                                 "the_vault:ornate_cascade",
                                 "@the_vault:companion_modifiers",
                                 "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -339,6 +339,106 @@
                 ]
             }
         ],
+        "the_vault:greed_wooden_t1": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:wooden_cascade",
+                                "the_vault:wooden_cascade",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 4,
+                                "max": 4,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_wooden_t2": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:wooden_cascade",
+                                "the_vault:wooden_cascade",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 4,
+                                "max": 4,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_wooden_t3": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:wooden_cascade",
+                                "the_vault:wooden_cascade",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 4,
+                                "max": 4,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_wooden_t4": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:wooden_cascade",
+                                "the_vault:wooden_cascade",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 4,
+                                "max": 4,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
         "the_vault:greed_ornate": [
             {
                 "level": 0,

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -190,6 +190,7 @@
                             "modifiers": [
                                 "the_vault:coin_cascade",
                                 "the_vault:coin_cascade",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -654,6 +654,106 @@
 
                 ]
             }
+        ],
+        "the_vault:greed_plentiful_t1": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:plentiful",
+                                "the_vault:plentiful",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 5,
+                                "max": 5,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_plentiful_t2": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:plentiful",
+                                "the_vault:plentiful",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 5,
+                                "max": 5,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_plentiful_t3": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:plentiful",
+                                "the_vault:plentiful",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 5,
+                                "max": 5,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_plentiful_t4": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:plentiful",
+                                "the_vault:plentiful",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 5,
+                                "max": 5,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
         ]
     },
     "relicChances": {

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -206,6 +206,114 @@
                 ]
             }
         ],
+        "the_vault:greed_coins_t1": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:coin_cascade",
+                                "the_vault:coin_cascade",
+                                "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 2,
+                                "max": 2,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_coins_t2": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:coin_cascade",
+                                "the_vault:coin_cascade",
+                                "@the_vault:companion_modifiers",
+                                "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 2,
+                                "max": 2,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_coins_t3": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:coin_cascade",
+                                "the_vault:coin_cascade",
+                                "the_vault:coin_cascade",
+                                "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 2,
+                                "max": 2,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_coins_t4": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:coin_cascade",
+                                "the_vault:coin_cascade",
+                                "the_vault:coin_cascade",
+                                "@the_vault:companion_modifiers",
+                                "@the_vault:companion_modifiers",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 2,
+                                "max": 2,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
         "the_vault:greed_wooden": [
             {
                 "level": 0,

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -190,7 +190,6 @@
                             "modifiers": [
                                 "the_vault:coin_cascade",
                                 "the_vault:coin_cascade",
-                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -472,6 +472,106 @@
                 ]
             }
         ],
+        "the_vault:greed_ornate_t1": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:ornate_cascade",
+                                "the_vault:ornate_cascade",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 1,
+                                "max": 1,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:_t2": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:ornate_cascade",
+                                "the_vault:ornate_cascade",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 1,
+                                "max": 1,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_ornate_t3": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:ornate_cascade",
+                                "the_vault:ornate_cascade",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 1,
+                                "max": 1,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
+        "the_vault:greed_ornate_t4": [
+            {
+                "level": 0,
+                "pool": [
+                    {
+                        "value": {
+                            "modifiers": [
+                                "the_vault:ornate_cascade",
+                                "the_vault:ornate_cascade",
+                                "the_vault:companion_challenge",
+                                "the_vault:companion_challenge"
+                            ],
+                            "model": {
+                                "min": 1,
+                                "max": 1,
+                                "type": "uniform"
+                            },
+                            "isGreed": true
+                        },
+                        "weight": 20.0
+                    }
+
+                ]
+            }
+        ],
         "the_vault:greed_gilded": [
             {
                 "level": 0,

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -561,6 +561,9 @@
                             "modifiers": [
                                 "the_vault:ornate_cascade",
                                 "the_vault:ornate_cascade",
+                                "the_vault:ornate_cascade",
+                                "@the_vault:companion_modifiers",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -534,6 +534,8 @@
                             "modifiers": [
                                 "the_vault:ornate_cascade",
                                 "the_vault:ornate_cascade",
+                                "the_vault:ornate_cascade",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -507,6 +507,8 @@
                             "modifiers": [
                                 "the_vault:ornate_cascade",
                                 "the_vault:ornate_cascade",
+                                "@the_vault:companion_modifiers",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],

--- a/config/the_vault/companion_relics.json
+++ b/config/the_vault/companion_relics.json
@@ -481,6 +481,7 @@
                             "modifiers": [
                                 "the_vault:ornate_cascade",
                                 "the_vault:ornate_cascade",
+                                "@the_vault:companion_modifiers",
                                 "the_vault:companion_challenge",
                                 "the_vault:companion_challenge"
                             ],

--- a/config/the_vault/gen/1.0/loot_tables/treasure_chest_50.json
+++ b/config/the_vault/gen/1.0/loot_tables/treasure_chest_50.json
@@ -51,7 +51,7 @@
             },
 
             {
-              "weight": 4,
+              "weight": 2,
               "item": {
                 "id": "the_vault:sour_orange",
                 "count": {
@@ -84,7 +84,7 @@
               }
             },
             {
-              "weight": 4,
+              "weight": 2,
               "item": {
                 "id": "the_vault:vault_catalyst_chaos",
                 "count": {
@@ -112,7 +112,7 @@
               }
             },
             {
-              "weight": 4,
+              "weight": 3,
               "item": {
                 "id": "the_vault:resilient_focus",
                 "count": {
@@ -123,7 +123,7 @@
               }
             },
             {
-              "weight": 4,
+              "weight": 2,
               "item": {
                 "id": "the_vault:recharge_core",
                 "count": {
@@ -134,7 +134,7 @@
               }
             },
             {
-              "weight": 4,
+              "weight": 1,
               "item": {
                 "id": "the_vault:crystal_seal_raid_infinite",
                 "count": {
@@ -253,7 +253,7 @@
               }
             },
             {
-              "weight": 1,
+              "weight": 4,
               "item": {
                 "id": "the_vault:treasure_chest_scroll",
                 "count": {
@@ -264,7 +264,7 @@
               }
             },
             {
-              "weight": 1,
+              "weight": 4,
               "item": {
                 "id": "woldsvaults:wold_star_chunk",
                 "count": {
@@ -275,7 +275,7 @@
               }
             },
             {
-              "weight": 1,
+              "weight": 4,
               "item": {
                 "id": "the_vault:mystic_pear",
                 "count": {
@@ -286,7 +286,7 @@
               }
             },
             {
-              "weight": 2,
+              "weight": 4,
               "item": {
                 "id": "woldsvaults:inscription_box",
                 "count": {

--- a/config/the_vault/gen/1.0/loot_tables/treasure_chest_50.json
+++ b/config/the_vault/gen/1.0/loot_tables/treasure_chest_50.json
@@ -286,7 +286,7 @@
               }
             },
             {
-              "weight": 4,
+              "weight": 5,
               "item": {
                 "id": "woldsvaults:inscription_box",
                 "count": {
@@ -297,7 +297,7 @@
               }
             },
             {
-              "weight": 4,
+              "weight": 5,
               "item": {
                 "id": "woldsvaults:omega_box",
                 "count": {

--- a/config/the_vault/gen/1.0/loot_tables/treasure_chest_map.json
+++ b/config/the_vault/gen/1.0/loot_tables/treasure_chest_map.json
@@ -200,7 +200,7 @@
               }
             },
             {
-              "weight": 4,
+              "weight": 2,
               "item": {
                 "id": "the_vault:trinket",
                 "count": {
@@ -217,7 +217,7 @@
           "pool": [
 
             {
-              "weight": 4,
+              "weight": 2,
               "item": {
                 "id": "the_vault:temporal_shard",
                 "count": {
@@ -228,7 +228,7 @@
               }
             },
             {
-              "weight": 4,
+              "weight": 2,
               "item": {
                 "id": "the_vault:opportunistic_focus",
                 "count": {
@@ -253,7 +253,7 @@
               }
             },
             {
-              "weight": 1,
+              "weight": 4,
               "item": {
                 "id": "the_vault:treasure_chest_scroll",
                 "count": {
@@ -264,7 +264,7 @@
               }
             },
             {
-              "weight": 1,
+              "weight": 4,
               "item": {
                 "id": "woldsvaults:wold_star_chunk",
                 "count": {
@@ -275,7 +275,7 @@
               }
             },
             {
-              "weight": 1,
+              "weight": 4,
               "item": {
                 "id": "the_vault:mystic_pear",
                 "count": {
@@ -286,7 +286,7 @@
               }
             },
             {
-              "weight": 2,
+              "weight": 4,
               "item": {
                 "id": "woldsvaults:inscription_box",
                 "count": {
@@ -308,7 +308,7 @@
               }
             },
             {
-              "weight": 2,
+              "weight": 5,
               "item": {
                 "id": "the_vault:inscription",
                 "nbt": {

--- a/config/the_vault/greed/greed_cauldron.json
+++ b/config/the_vault/greed/greed_cauldron.json
@@ -138,11 +138,6 @@
       "maxAmount": 1000
     },
     {
-      "item": "the_vault:spicy_hearty_burger",
-      "minAmount": 2,
-      "maxAmount": 4
-    },
-    {
       "item": "the_vault:cheese_burger_feast",
       "minAmount": 50,
       "maxAmount": 100

--- a/config/the_vault/greed/greed_nodes.json
+++ b/config/the_vault/greed/greed_nodes.json
@@ -526,14 +526,14 @@
       },
       {
         "id": "off_t3_dmg_assassin_1",
-        "name": "+25% Dmg to Greed Assassins",
+        "name": "+100% Dmg to Greed Assassins",
         "present": false,
         "parent": "off_t1_atk_ap_9",
         "tier": 3,
         "entries": [
           {
             "attribute": "the_vault:damage_assassin",
-            "value": 0.25
+            "value": 1.00
           }
         ],
         "type": "greed_gear_attribute"
@@ -969,14 +969,14 @@
       },
       {
         "id": "def_t1_assassin_res_1",
-        "name": "+10% Dmg Reduction from Greed Assassins",
+        "name": "+25% Dmg Reduction from Greed Assassins",
         "present": false,
         "parent": "def_t2_crit_mitigation_1",
         "tier": 1,
         "entries": [
           {
             "attribute": "the_vault:resistance_greed_assassin",
-            "value": 0.1
+            "value": 0.25
           }
         ],
         "type": "greed_gear_attribute"

--- a/config/the_vault/greed/greed_trader.json
+++ b/config/the_vault/greed/greed_trader.json
@@ -1258,7 +1258,7 @@
         "maxGreedTier": 8,
         "itemStack": {
           "item": "the_vault:companion_relic",
-          "nbt": "{pool:\"the_vault:greed_ornate\"}"
+          "nbt": "{pool:\"the_vault:greed_ornate_t1\"}"
         }
       },
       {
@@ -1314,7 +1314,7 @@
         "maxGreedTier": 11,
         "itemStack": {
           "item": "the_vault:companion_relic",
-          "nbt": "{pool:\"the_vault:greed_ornate\"}"
+          "nbt": "{pool:\"the_vault:greed_ornate_t2\"}"
         }
       },
       {
@@ -1370,7 +1370,7 @@
         "maxGreedTier": -1,
         "itemStack": {
           "item": "the_vault:companion_relic",
-          "nbt": "{pool:\"the_vault:greed_ornate\"}"
+          "nbt": "{pool:\"the_vault:greed_ornate_t3\"}"
         }
       },
       {

--- a/config/the_vault/greed/greed_trader.json
+++ b/config/the_vault/greed/greed_trader.json
@@ -138,6 +138,13 @@
         "maxCoinCost": 39
       },
       {
+        "type": "pool",
+        "weight": 2,
+        "poolId": "greed_companion_relics",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
+      },
+      {
         "type": "xp_burger",
         "weight": 1,
         "minAmount": 2000000,
@@ -201,6 +208,13 @@
         "poolId": "greed_catalysts_t1",
         "minCoinCost": 26,
         "maxCoinCost": 41
+      },
+      {
+        "type": "pool",
+        "weight": 2,
+        "poolId": "greed_companion_relics",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "xp_burger",

--- a/config/the_vault/greed/greed_trader.json
+++ b/config/the_vault/greed/greed_trader.json
@@ -1245,35 +1245,35 @@
       },
       {
         "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "minGreedTier": 6,
+        "maxGreedTier": 8,
         "itemStack": {
           "item": "the_vault:companion_relic",
-          "nbt": "{pool:\"the_vault:greed_wooden\"}"
+          "nbt": "{pool:\"the_vault:greed_wooden_t1\"}"
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "weight": 5,
+        "minGreedTier": 6,
+        "maxGreedTier": 8,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_ornate\"}"
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "weight": 5,
+        "minGreedTier": 6,
+        "maxGreedTier": 8,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_gilded\"}"
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "weight": 5,
+        "minGreedTier": 6,
+        "maxGreedTier": 8,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_living\"}"
@@ -1281,8 +1281,8 @@
       },
       {
         "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "minGreedTier": 6,
+        "maxGreedTier": 8,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_plentiful\"}"
@@ -1301,35 +1301,35 @@
       },
       {
         "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "minGreedTier": 9,
+        "maxGreedTier": 11,
         "itemStack": {
           "item": "the_vault:companion_relic",
-          "nbt": "{pool:\"the_vault:greed_wooden\"}"
+          "nbt": "{pool:\"the_vault:greed_wooden_t2\"}"
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "weight": 5,
+        "minGreedTier": 9,
+        "maxGreedTier": 11,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_ornate\"}"
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "weight": 5,
+        "minGreedTier": 9,
+        "maxGreedTier": 11,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_gilded\"}"
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "weight": 5,
+        "minGreedTier": 9,
+        "maxGreedTier": 11,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_living\"}"
@@ -1337,8 +1337,8 @@
       },
       {
         "weight": 10,
-        "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "minGreedTier": 9,
+        "maxGreedTier": 11,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_plentiful\"}"
@@ -1347,7 +1347,7 @@
     ],
     "greed_companion_relics_t3": [
       {
-        "weight": 69420,
+        "weight": 10,
         "minGreedTier": 12,
         "maxGreedTier": -1,
         "itemStack": {
@@ -1357,16 +1357,16 @@
       },
       {
         "weight": 10,
-        "minGreedTier": 0,
+        "minGreedTier": 12,
         "maxGreedTier": -1,
         "itemStack": {
           "item": "the_vault:companion_relic",
-          "nbt": "{pool:\"the_vault:greed_wooden\"}"
+          "nbt": "{pool:\"the_vault:greed_wooden_t3\"}"
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
+        "weight": 5,
+        "minGreedTier": 12,
         "maxGreedTier": -1,
         "itemStack": {
           "item": "the_vault:companion_relic",
@@ -1374,8 +1374,8 @@
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
+        "weight": 5,
+        "minGreedTier": 12,
         "maxGreedTier": -1,
         "itemStack": {
           "item": "the_vault:companion_relic",
@@ -1383,8 +1383,8 @@
         }
       },
       {
-        "weight": 10,
-        "minGreedTier": 0,
+        "weight": 5,
+        "minGreedTier": 12,
         "maxGreedTier": -1,
         "itemStack": {
           "item": "the_vault:companion_relic",
@@ -1393,7 +1393,7 @@
       },
       {
         "weight": 10,
-        "minGreedTier": 0,
+        "minGreedTier": 12,
         "maxGreedTier": -1,
         "itemStack": {
           "item": "the_vault:companion_relic",

--- a/config/the_vault/greed/greed_trader.json
+++ b/config/the_vault/greed/greed_trader.json
@@ -43,6 +43,7 @@
         "minCoinCost": 20,
         "maxCoinCost": 35
       }
+
     ],
     "2": [
       {
@@ -268,13 +269,6 @@
       },
       {
         "type": "pool",
-        "weight": 2,
-        "poolId": "greed_companion_relics_t1",
-        "minCoinCost": 66,
-        "maxCoinCost": 106
-      },
-      {
-        "type": "pool",
         "weight": 3,
         "poolId": "catalyst_t2",
         "minCoinCost": 25,
@@ -347,10 +341,10 @@
       },
       {
         "type": "pool",
-        "weight": 2,
-        "poolId": "greed_companion_relics",
-        "minCoinCost": 35,
-        "maxCoinCost": 55
+        "weight": 69420,
+        "poolId": "greed_companion_relics_t1",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "pool",
@@ -433,10 +427,10 @@
       },
       {
         "type": "pool",
-        "weight": 2,
-        "poolId": "greed_companion_relics",
-        "minCoinCost": 37,
-        "maxCoinCost": 57
+        "weight": 69420,
+        "poolId": "greed_companion_relics_t1",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "pool",
@@ -519,10 +513,10 @@
       },
       {
         "type": "pool",
-        "weight": 2,
-        "poolId": "greed_companion_relics",
-        "minCoinCost": 39,
-        "maxCoinCost": 59
+        "weight": 69420,
+        "poolId": "greed_companion_relics_t1",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "pool",
@@ -605,10 +599,10 @@
       },
       {
         "type": "pool",
-        "weight": 2,
-        "poolId": "greed_companion_relics",
-        "minCoinCost": 41,
-        "maxCoinCost": 61
+        "weight": 69420,
+        "poolId": "greed_companion_relics_t2",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "pool",
@@ -691,10 +685,10 @@
       },
       {
         "type": "pool",
-        "weight": 2,
-        "poolId": "greed_companion_relics",
-        "minCoinCost": 43,
-        "maxCoinCost": 63
+        "weight": 69420,
+        "poolId": "greed_companion_relics_t2",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "pool",
@@ -784,8 +778,8 @@
       },
       {
         "type": "pool",
-        "weight": 2,
-        "poolId": "greed_companion_relics",
+        "weight": 69420,
+        "poolId": "greed_companion_relics_t2",
         "minCoinCost": 45,
         "maxCoinCost": 65
       },
@@ -877,10 +871,10 @@
       },
       {
         "type": "pool",
-        "weight": 2,
-        "poolId": "greed_companion_relics",
-        "minCoinCost": 47,
-        "maxCoinCost": 67
+        "weight": 69420,
+        "poolId": "greed_companion_relics_t3",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "pool",
@@ -1227,12 +1221,124 @@
     ],
     "greed_companion_relics_t1": [
       {
-        "weight": 5,
-        "minGreedTier": 3,
-        "maxGreedTier": 5,
+        "weight": 69420,
+        "minGreedTier": 6,
+        "maxGreedTier": 8,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_coins_t1\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_wooden\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_ornate\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_gilded\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_living\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_plentiful\"}"
+        }
+      }
+    ],
+    "greed_companion_relics_t2": [
+      {
+        "weight": 69420,
+        "minGreedTier": 9,
+        "maxGreedTier": 11,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_coins_t2\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_wooden\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_ornate\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_gilded\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_living\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_plentiful\"}"
+        }
+      }
+    ],
+    "greed_companion_relics_t3": [
+      {
+        "weight": 69420,
+        "minGreedTier": 12,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_coins_t3\"}"
         }
       },
       {

--- a/config/the_vault/greed/greed_trader.json
+++ b/config/the_vault/greed/greed_trader.json
@@ -145,6 +145,13 @@
         "maxCoinCost": 106
       },
       {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
+      },
+      {
         "type": "xp_burger",
         "weight": 1,
         "minAmount": 2000000,
@@ -213,6 +220,13 @@
         "type": "pool",
         "weight": 2,
         "poolId": "greed_companion_relics",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
+      },
+      {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
         "minCoinCost": 66,
         "maxCoinCost": 106
       },
@@ -294,6 +308,13 @@
         "poolId": "greed_catalysts_t1",
         "minCoinCost": 28,
         "maxCoinCost": 43
+      },
+      {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "xp_burger",
@@ -382,6 +403,13 @@
         "maxCoinCost": 42
       },
       {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
+      },
+      {
         "type": "xp_burger",
         "weight": 1,
         "minAmount": 2000000,
@@ -466,6 +494,13 @@
         "poolId": "greed_catalysts_t2",
         "minCoinCost": 27,
         "maxCoinCost": 46
+      },
+      {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "xp_burger",
@@ -554,6 +589,13 @@
         "maxCoinCost": 50
       },
       {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
+      },
+      {
         "type": "xp_burger",
         "weight": 1,
         "minAmount": 2000000,
@@ -638,6 +680,13 @@
         "poolId": "greed_catalysts_t2",
         "minCoinCost": 31,
         "maxCoinCost": 54
+      },
+      {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "xp_burger",
@@ -733,6 +782,13 @@
         "maxCoinCost": 58
       },
       {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
+      },
+      {
         "type": "xp_burger",
         "weight": 1,
         "minAmount": 2000000,
@@ -826,6 +882,13 @@
         "maxCoinCost": 62
       },
       {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
+      },
+      {
         "type": "xp_burger",
         "weight": 1,
         "minAmount": 2000000,
@@ -917,6 +980,13 @@
         "poolId": "greed_catalysts_t2",
         "minCoinCost": 37,
         "maxCoinCost": 66
+      },
+      {
+        "type": "pool",
+        "weight": 4,
+        "poolId": "general_items",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
       },
       {
         "type": "xp_burger",
@@ -1087,7 +1157,6 @@
           "item": "woldsvaults:omega_box"
         }
       }
-
     ],
     "companion_super_relics": [],
     "modified_super_inscriptions": [],

--- a/config/the_vault/greed/greed_trader.json
+++ b/config/the_vault/greed/greed_trader.json
@@ -376,7 +376,7 @@
       },
       {
         "type": "pool",
-        "weight": 69420,
+        "weight": 2,
         "poolId": "greed_companion_relics_t1",
         "minCoinCost": 66,
         "maxCoinCost": 106
@@ -469,7 +469,7 @@
       },
       {
         "type": "pool",
-        "weight": 69420,
+        "weight": 2,
         "poolId": "greed_companion_relics_t1",
         "minCoinCost": 66,
         "maxCoinCost": 106
@@ -562,7 +562,7 @@
       },
       {
         "type": "pool",
-        "weight": 69420,
+        "weight": 2,
         "poolId": "greed_companion_relics_t1",
         "minCoinCost": 66,
         "maxCoinCost": 106
@@ -655,7 +655,7 @@
       },
       {
         "type": "pool",
-        "weight": 69420,
+        "weight": 2,
         "poolId": "greed_companion_relics_t2",
         "minCoinCost": 66,
         "maxCoinCost": 106
@@ -748,7 +748,7 @@
       },
       {
         "type": "pool",
-        "weight": 69420,
+        "weight": 2,
         "poolId": "greed_companion_relics_t2",
         "minCoinCost": 66,
         "maxCoinCost": 106
@@ -848,7 +848,7 @@
       },
       {
         "type": "pool",
-        "weight": 69420,
+        "weight": 2,
         "poolId": "greed_companion_relics_t2",
         "minCoinCost": 45,
         "maxCoinCost": 65
@@ -948,7 +948,7 @@
       },
       {
         "type": "pool",
-        "weight": 69420,
+        "weight": 2,
         "poolId": "greed_companion_relics_t3",
         "minCoinCost": 66,
         "maxCoinCost": 106
@@ -1150,7 +1150,7 @@
     ],
     "general_items": [
       {
-        "weight": 10,
+        "weight": 2,
         "minGreedTier": 3,
         "maxGreedTier": -1,
         "itemStack": {
@@ -1315,7 +1315,7 @@
     ],
     "greed_companion_relics_t1": [
       {
-        "weight": 69420,
+        "weight": 10,
         "minGreedTier": 6,
         "maxGreedTier": 8,
         "itemStack": {
@@ -1371,7 +1371,7 @@
     ],
     "greed_companion_relics_t2": [
       {
-        "weight": 69420,
+        "weight": 10,
         "minGreedTier": 9,
         "maxGreedTier": 11,
         "itemStack": {

--- a/config/the_vault/greed/greed_trader.json
+++ b/config/the_vault/greed/greed_trader.json
@@ -268,6 +268,13 @@
       },
       {
         "type": "pool",
+        "weight": 2,
+        "poolId": "greed_companion_relics_t1",
+        "minCoinCost": 66,
+        "maxCoinCost": 106
+      },
+      {
+        "type": "pool",
         "weight": 3,
         "poolId": "catalyst_t2",
         "minCoinCost": 25,
@@ -1166,10 +1173,66 @@
       {
         "weight": 10,
         "minGreedTier": 0,
-        "maxGreedTier": -1,
+        "maxGreedTier": 2,
         "itemStack": {
           "item": "the_vault:companion_relic",
           "nbt": "{pool:\"the_vault:greed_coins\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_wooden\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_ornate\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_gilded\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_living\"}"
+        }
+      },
+      {
+        "weight": 10,
+        "minGreedTier": 0,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_plentiful\"}"
+        }
+      }
+    ],
+    "greed_companion_relics_t1": [
+      {
+        "weight": 5,
+        "minGreedTier": 3,
+        "maxGreedTier": 5,
+        "itemStack": {
+          "item": "the_vault:companion_relic",
+          "nbt": "{pool:\"the_vault:greed_coins_t1\"}"
         }
       },
       {

--- a/config/the_vault/greed/greed_trader.json
+++ b/config/the_vault/greed/greed_trader.json
@@ -1078,6 +1078,17 @@
         }
       }
     ],
+    "general_items": [
+      {
+        "weight": 10,
+        "minGreedTier": 3,
+        "maxGreedTier": -1,
+        "itemStack": {
+          "item": "woldsvaults:omega_box"
+        }
+      }
+
+    ],
     "companion_super_relics": [],
     "modified_super_inscriptions": [],
     "super_inscriptions": [


### PR DESCRIPTION
This change would add items to greed trader, namely;

Higher tier Companion Relics

Omega Boxes

I think the greed trades are a bit underwhelming, especially since it's the same 5 items over and over. Compared to their ancient relic counterparts, the greedy companion relics are extremely bad, only having 2 modifiers by default. This change still keeps that 2 modifier default, but also adds another random one, and some more

Earliest greed tier to get these relics is tier 6

at tier 9, t2 is unlocked, which adds another random modifier

at tier 12, t3 is unlocked, which guarantees 3 of the same modifier (Only wealthy, wooden, and ornate are implemented rn), along with 2 random mods

This makes getting to t12 for companion relics worth it, and contests with ancient relics while not being 100% better than them if you get a good roll on those

Also adds omega boxes to trader, I think weight can be fine tuned if you want, but was planning to add more to the random item pool to balance the loot table a bit 
