### PR TITLE
deps(autocrafting): bump vault-autocrafting-fix

### DIFF
--- a/mods/vault-autocrafting-fix.pw.toml
+++ b/mods/vault-autocrafting-fix.pw.toml
@@ -1,13 +1,13 @@
 name = "Vault Autocrafting Fix"
-filename = "vault_autocrafting-1.18.2-3.15.2-1.1.4.jar"
+filename = "vault_autocrafting-1.18.2-1.2.0.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "40034a9d8a14952eb87883468a18af4c5cc3f9b3"
+hash = "a2102880ded4b2ac5b700a929077a5225d195b3d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 6372049
+file-id = 8142260
 project-id = 1096429


### PR DESCRIPTION
Does what it says in the title.

Changelog from mod:
- Added RFTools Utility support
- Added method of reporting fancy messages in chat
  - Currently only used within RFTools Utility, others shall come later.

