### PR TITLE
Add mythic pools to config

### DIFF
--- a/config/the_vault/gen/1.0/loot_tables/gilded_chest_100_map.json
+++ b/config/the_vault/gen/1.0/loot_tables/gilded_chest_100_map.json
@@ -254,6 +254,55 @@
               }
             }
           ]
+        },
+        {
+          "weight": 0.00445,
+          "pool": [
+            {
+              "weight": 100,
+              "item": {
+                "id": "the_vault:vault_diamond",
+                "count": {
+                  "type": "uniform",
+                  "min": 4,
+                  "max": 8
+                }
+              }
+            },
+            {
+              "weight": 50,
+              "item": {
+                "id": "the_vault:jewel_pouch",
+                "count": {
+                  "type": "uniform",
+                  "min": 6,
+                  "max": 8
+                }
+              }
+            },
+            {
+              "weight": 50,
+              "item": {
+                "id": "the_vault:dreamstone",
+                "count": {
+                  "type": "uniform",
+                  "min": 6,
+                  "max": 8
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:key_piece",
+                "count": {
+                  "type": "uniform",
+                  "min": 4,
+                  "max": 6
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/config/the_vault/gen/1.0/loot_tables/gilded_strongbox_100_map.json
+++ b/config/the_vault/gen/1.0/loot_tables/gilded_strongbox_100_map.json
@@ -280,6 +280,81 @@
               }
             }
           ]
+        },
+        {
+          "weight": 0.00445,
+          "pool": [
+            {
+              "weight": 200,
+              "item": {
+                "id": "the_vault:vault_diamond",
+                "count": {
+                  "type": "uniform",
+                  "min": 8,
+                  "max": 12
+                }
+              }
+            },
+            {
+              "weight": 100,
+              "item": {
+                "id": "the_vault:jewel_pouch",
+                "count": {
+                  "type": "uniform",
+                  "min": 5,
+                  "max": 10
+                }
+              }
+            },
+            {
+              "weight": 33,
+              "item": {
+                "id": "woldsvaults:altar_recatalyzer",
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 20,
+              "item": {
+                "id": "the_vault:trinket",
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 20,
+              "item": {
+                "id": "woldsvaults:catalyst_box",
+                "count": {
+                  "type": "uniform",
+                  "min": 2,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 1,
+              "item": {
+                "id": "the_vault:map",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "gear_completion",
+                  "the_vault:map_tier": -1
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/config/the_vault/gen/1.0/loot_tables/living_chest_100_map.json
+++ b/config/the_vault/gen/1.0/loot_tables/living_chest_100_map.json
@@ -329,6 +329,58 @@
               }
             }
           ]
+        },
+        {
+          "weight": 0.00445,
+          "pool": [
+            {
+              "weight": 100,
+              "item": {
+                "id": "the_vault:knowledge_star_essence",
+                "count": {
+                  "type": "uniform",
+                  "min": 16,
+                  "max": 32
+                }
+              }
+            },
+            {
+              "weight": 25,
+              "item": {
+                "id": "woldsvaults:soul_ichor",
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 3
+                }
+              }
+            },
+            {
+              "weight": 20,
+              "item": {
+                "id": "the_vault:burger_chili",
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 13,
+              "item": {
+                "id": "the_vault:inscription",
+                "nbt": {
+                  "pool": "the_vault:random"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/config/the_vault/gen/1.0/loot_tables/living_strongbox_100_map.json
+++ b/config/the_vault/gen/1.0/loot_tables/living_strongbox_100_map.json
@@ -355,6 +355,70 @@
               }
             }
           ]
+        },
+        {
+          "weight": 0.00445,
+          "pool": [
+            {
+              "weight": 1,
+              "item": {
+                "id": "the_vault:map",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "gear_completion",
+                  "the_vault:map_tier": -1
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 50,
+              "item": {
+                "id": "the_vault:knowledge_star_essence",
+                "count": {
+                  "type": "uniform",
+                  "min": 16,
+                  "max": 32
+                }
+              }
+            },
+            {
+              "weight": 20,
+              "item": {
+                "id": "woldsvaults:soul_ichor",
+                "count": {
+                  "type": "uniform",
+                  "min": 4,
+                  "max": 8
+                }
+              }
+            },
+            {
+              "weight": 6,
+              "item": {
+                "id": "woldsvaults:unidentified_gateway_pearl",
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 20,
+              "item": {
+                "id": "the_vault:burger_chili",
+                "count": {
+                  "type": "uniform",
+                  "min": 5,
+                  "max": 10
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/config/the_vault/gen/1.0/loot_tables/ornate_chest_100_map.json
+++ b/config/the_vault/gen/1.0/loot_tables/ornate_chest_100_map.json
@@ -411,6 +411,209 @@
               }
             }
           ]
+        },
+        {
+          "weight": 0.00445,
+          "pool": [
+            {
+              "weight": 30,
+              "item": {
+                "id": "the_vault:carbon",
+                "count": {
+                  "type": "uniform",
+                  "min": 10,
+                  "max": 20
+                }
+              }
+            },
+            {
+              "weight": 15,
+              "item": {
+                "id": "the_vault:fundamental_focus",
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 3
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:vault_necklace",
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:opportunistic_focus",
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:boots",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:leggings",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:chestplate",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:helmet",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:trident",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:battlestaff",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:sword",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:axe",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:shield",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:wand",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:focus",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "map_loot"
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/config/the_vault/gen/1.0/loot_tables/ornate_strongbox_100_map.json
+++ b/config/the_vault/gen/1.0/loot_tables/ornate_strongbox_100_map.json
@@ -484,6 +484,125 @@
               }
             }
           ]
+        },
+        {
+          "weight": 0.00445,
+          "pool": [
+            {
+              "weight": 50,
+              "item": {
+                "id": "the_vault:vault_alloy",
+                "count": {
+                  "type": "uniform",
+                  "min": 7,
+                  "max": 14
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "woldsvaults:blazing_focus",
+                "count": {
+                  "type": "uniform",
+                  "min": 2,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:resilient_focus",
+                "count": {
+                  "type": "uniform",
+                  "min": 2,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:cryonic_focus",
+                "count": {
+                  "type": "uniform",
+                  "min": 2,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:pyretic_focus",
+                "count": {
+                  "type": "uniform",
+                  "min": 2,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:empowered_chaotic_focus",
+                "count": {
+                  "type": "uniform",
+                  "min": 2,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 1,
+              "item": {
+                "id": "the_vault:map",
+                "nbt": {
+                  "the_vault:gear_roll_type_pool": "gear_completion",
+                  "the_vault:map_tier": -1
+                },
+                "count": {
+                  "type": "uniform",
+                  "min": 1,
+                  "max": 1
+                }
+              }
+            },
+            {
+              "weight": 10,
+              "item": {
+                "id": "woldsvaults:repair_augmenter",
+                "count": {
+                  "type": "uniform",
+                  "min": 2,
+                  "max": 2
+                }
+              }
+            },
+            {
+              "weight": 80,
+              "item": {
+                "id": "the_vault:fundamental_focus",
+                "count": {
+                  "type": "uniform",
+                  "min": 3,
+                  "max": 6
+                }
+              }
+            },
+            {
+              "weight": 200,
+              "item": {
+                "id": "the_vault:carbon",
+                "count": {
+                  "type": "uniform",
+                  "min": 10,
+                  "max": 20
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/config/the_vault/gen/1.0/loot_tables/wooden_chest_map.json
+++ b/config/the_vault/gen/1.0/loot_tables/wooden_chest_map.json
@@ -213,6 +213,55 @@
               }
             }
           ]
+        },
+        {
+          "weight": 0.00445,
+          "pool": [
+            {
+              "weight": 10,
+              "item": {
+                "id": "the_vault:mod_box",
+                "count": {
+                  "type": "uniform",
+                  "min": 3,
+                  "max": 6
+                }
+              }
+            },
+            {
+              "weight": 5,
+              "item": {
+                "id": "woldsvaults:augment_box",
+                "count": {
+                  "type": "uniform",
+                  "min": 2,
+                  "max": 4
+                }
+              }
+            },
+            {
+              "weight": 30,
+              "item": {
+                "id": "the_vault:bounty_pearl",
+                "count": {
+                  "type": "uniform",
+                  "min": 5,
+                  "max": 10
+                }
+              }
+            },
+            {
+              "weight": 40,
+              "item": {
+                "id": "the_vault:vault_plating",
+                "count": {
+                  "type": "uniform",
+                  "min": 32,
+                  "max": 64
+                }
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Adds the mythic pools to the chest loot configs for mapped vaults for the new IR system to take into effect. if these are missing, defaults back to the 4 pool system easily. merge the mod PR first for safest results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)