### PR TITLE
update jer loot table sync

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -23660,7 +23660,7 @@ metafile = true
 
 [[files]]
 file = "mods/jer-loot-table-sync.pw.toml"
-hash = "8b03847cb3bfb6cd96f1139d1bb7cc604765314226bb13d562686e3e578e132c"
+hash = "f910af893aa0bc197f1b9a9299700739fe3206ac827670ffe2b94e12b9bcf334"
 metafile = true
 
 [[files]]

--- a/mods/jer-loot-table-sync.pw.toml
+++ b/mods/jer-loot-table-sync.pw.toml
@@ -1,13 +1,13 @@
 name = "JER Loot Table Sync"
-filename = "jer_loot_tables_sync-1.0.0.jar"
+filename = "jer_loot_tables_sync-1.2.0.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "59047c6bb7739fecaa164438219d773f9cd8b0af"
+hash = "b16cb88d09b3b356f95095a8e5ec2542544d41e0"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7630267
+file-id = 8504742
 project-id = 1463301

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "5a6d896afa173f115ef0daecd49cff33baa2a56074d9a391bc5c7f349301dbd4"
+hash = "5f421a5ae5300daa5259ee27780e00866f009106f26b8842072eb7882a3b0c61"
 
 [versions]
 forge = "40.3.11"


### PR DESCRIPTION
**REQUIRES SERVER PACK UDPATE**

sync stack count for dungeon chests
no longer sync trivial loot tables to save memory on the client (like dirt drops dirt)
