### PR TITLE
update mods

### DIFF
--- a/mods/jer-loot-table-sync.pw.toml
+++ b/mods/jer-loot-table-sync.pw.toml
@@ -1,13 +1,13 @@
 name = "JER Loot Table Sync"
-filename = "jer_loot_tables_sync-1.2.0.jar"
+filename = "jer_loot_tables_sync-1.3.0.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "b16cb88d09b3b356f95095a8e5ec2542544d41e0"
+hash = "28c7d35457755dd8d81cb98461d6b7b0bb60c64f"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 8504742
+file-id = 8675793
 project-id = 1463301

--- a/mods/mob-processor.pw.toml
+++ b/mods/mob-processor.pw.toml
@@ -1,13 +1,13 @@
 name = "Mob Processor"
-filename = "mobprocessor-1.0.jar"
+filename = "mobprocessor-1.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "b3146ef49c1d72da2553784ac1bd5c42047b7e95"
+hash = "0501b689bbf4f4705d74c9e63d56d717bf456e86"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7802222
+file-id = 8716485
 project-id = 1494033


### PR DESCRIPTION
fixes chickens spawning from mob processor
fixes modded mob eggs not being added to JER - you can now right click eggs that come from vault hostile eggs to see 